### PR TITLE
Update nav-loop SKILL.md with v2 exit signal format

### DIFF
--- a/skills/nav-loop/SKILL.md
+++ b/skills/nav-loop/SKILL.md
@@ -257,7 +257,11 @@ Options:
 
 ### Step 7: Complete Loop
 
-**When exit conditions met**, display completion:
+**When exit conditions met**, emit the exit signal in JSON format and display completion:
+
+```pilot-signal
+{"v":2,"type":"exit","success":true,"reason":"All criteria met"}
+```
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -304,12 +308,19 @@ The EXIT_SIGNAL is set **explicitly by Claude** when:
 - Code is functional and tested
 - No obvious remaining work
 
-**How to signal completion**:
-```
-I've completed the implementation. All requirements met.
+**How to signal completion** (v2 JSON format):
 
-EXIT_SIGNAL: true
+```pilot-signal
+{"v":2,"type":"exit","success":true,"reason":"All requirements met"}
 ```
+
+The JSON format in a `pilot-signal` code block ensures unambiguous detection by Pilot automation. The `reason` field should briefly describe why the task is complete.
+
+**Signal fields**:
+- `v`: Version (always `2`)
+- `type`: Signal type (always `"exit"` for completion)
+- `success`: Whether task completed successfully (`true`/`false`)
+- `reason`: Brief explanation of completion state
 
 This explicit declaration prevents premature exits when heuristics are met but work remains.
 
@@ -443,8 +454,13 @@ Iteration 2 (IMPL):
 Iteration 3 (VERIFY):
   - Ran tests: PASS
   - Committed changes
-  EXIT_SIGNAL: true
+```
 
+```pilot-signal
+{"v":2,"type":"exit","success":true,"reason":"isPrime function implemented and tests passing"}
+```
+
+```
 → Loop complete in 3 iterations
 ```
 
@@ -464,8 +480,13 @@ User: "The test needs a mock for the auth service"
 Iteration 4 (IMPL):
   - Added mock
   - Tests pass
-  EXIT_SIGNAL: true
+```
 
+```pilot-signal
+{"v":2,"type":"exit","success":true,"reason":"Auth bug fixed with mock service"}
+```
+
+```
 → Loop complete in 4 iterations
 ```
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2.

Closes #2

## Changes

GitHub Issue #2: Update nav-loop SKILL.md with v2 exit signal format

## Summary
Update nav-loop skill documentation to use JSON-based exit signals for reliable Pilot detection.

## Changes
Update `skills/nav-loop/SKILL.md` Step 7 (Complete Loop) to emit exit signal as JSON:

```
```pilot-signal
{"v":2,"type":"exit","success":true,"reason":"All criteria met"}
```
```

Also update the "Setting EXIT_SIGNAL" section to show the new format.

## Why
- Text-based `EXIT_SIGNAL: true` can false-match in prose
- JSON in code blocks is unambiguous
- Matches status signal format for consistency

## Acceptance Criteria
- [ ] SKILL.md Step 7 shows JSON exit signal format
- [ ] "Setting EXIT_SIGNAL" section updated
- [ ] Examples updated to use new format

## Related
- Depends on #1 (status_generator.py changes)