### PR TITLE
Audit remediation: roadmap (TASK-42) + CI gate keystone (TASK-43, wp1)

### DIFF
--- a/.agent/tasks/TASK-25-fix-multi-claude-reliability.md
+++ b/.agent/tasks/TASK-25-fix-multi-claude-reliability.md
@@ -548,3 +548,23 @@ navigator-multi-claude.sh "Implement v4.5.0 multi-Claude reliability fixes from 
 4. Iterate on fixes based on real failure modes
 
 **Ready to execute?** 🚀
+
+---
+
+## Roadmap linkage (2026-06-02)
+
+This task is **work-package wp10** of the audit remediation roadmap (**TASK-42**). The 2026-06-02 project audit (`wf_0dc1b9ce-7d8`) independently confirmed 12 multi-Claude reliability findings that this task should absorb:
+
+- `set -e` aborts before per-phase error handlers run (graceful-failure code is dead)
+- `wait_for_file` hardcodes timeout=300, ignores its argument (per-phase tuning void)
+- retry loop re-polls disk instead of re-launching Claude
+- killing the background subshell PID orphans the spawned `claude` child
+- parallel phases launched together but waited on serially (parallelism defeated)
+- dashboard reads marker filenames the workflow never writes (loops forever)
+- `grep -q APPROVED` matches "not APPROVED" → auto-merges unreviewed work
+- `git add .` commits stray markers/.bak/unrelated changes
+- `scripts/lib/` is empty → helpers copy-pasted, bug duplicated
+- session state never records `started_at` (dashboard elapsed timer wrong)
+- `resume-workflow.sh` sets status 'resumed' without verifying the new marker
+
+**Decision pending** (see TASK-42): genuine repair vs mark-experimental/deprecate. Effort L, risk med.

--- a/.agent/tasks/TASK-42-audit-remediation-roadmap.md
+++ b/.agent/tasks/TASK-42-audit-remediation-roadmap.md
@@ -1,0 +1,101 @@
+# TASK-42: Audit Remediation Roadmap
+
+**Status**: 🗺️ Active (umbrella)
+**Created**: 2026-06-02
+**Priority**: High
+**Source**: 10-dimension audit `wf_0dc1b9ce-7d8` (86 verified findings) → remediation plan `wf_187896bb-5af`
+**Shipped already**: critical hook-manifest regression fixed in **v6.15.6**
+
+---
+
+## Summary
+
+Remediation runs in four dependency-respecting waves anchored on a CI gate that makes every subsequent fix verifiable. The keystone is wp1 (CI test + pre-publish validation gate): until it exists, the 233 unit tests never run automatically, the Makefile test target is a sham, and the exact v6.15.5 dead-hook/version-drift regression can recur — so every other fix would ship unverified. We front-load wp1 plus the no-dependency quick wins (wp8 skill-template trimming, wp2 version-tooling correctness) that derisk later doc and release work. Test coverage (wp4) lands immediately after the gate so it both runs in CI and protects the higher-risk hook/graph/detection fixes (wp5, wp6, wp7) that depend on it. The two heavy, independent script tracks (wp10 multi-Claude, wp11 misc Python) run in parallel where capacity allows since they touch neither the gate nor each other. Docs/config reconciliation (wp9) lands last because its SOP rewrite must reflect wp2's bump-script and release-path decisions.
+
+## Keystone
+
+Build wp1 (CI test job + pre-publish validation gate) first. Today release.yml is the only publish path, it runs zero tests, and it has no version-consistency / tag-vs-manifest / hook-path check — exactly the gap that let the v6.15.5 dead-hook + version-drift regression ship before the v6.15.6 hotfix. The Makefile `test` target is verified a no-op (it only exec's status_generator.py), so the 233 passing unit tests never execute automatically. Until wp1 wires per-directory unittest discovery (the 6 genuine dirs summing to 233, excluding the two mis-named non-test files) and adds release_validator --verify-hook-paths + tag==manifest assertions to a `validate` job that the `release` job needs:, every downstream fix (wp4-wp11) ships unverified and the regression class stays open. Land the test job non-blocking on push/PR first, then gate releases on the validate job once it is confirmed green against the clean v6.15.6 tree.
+
+## Work-Package Index
+
+| WP | Task | Phase | Effort | Risk | Deps | Rec |
+| --- | --- | --- | --- | --- | --- | --- |
+| `wp1-ci-gate` — CI test + pre-publish validation gate | TASK-43 | — | M | med | — | `fix+test` |
+| `wp2-version-tooling` — Version & release tooling correctness | TASK-44 | — | L | med | — | `fix+test` |
+| `wp8-skill-templates` — Skill template/reference integrity | TASK-50 | — | M | low | — | `fix-now` |
+| `wp4-hook-tests` — Test coverage for hooks & destructive/blocking paths | TASK-45 | — | L | med | TASK-43 | `fix+test` |
+| `wp5-hook-safety` — Hook correctness & safety fixes (non-path) | TASK-46 | — | M | med | TASK-45 | `fix+test` |
+| `wp6-kg-integrity` — Knowledge-graph data integrity + dormant maintenance wiring | TASK-47 | — | L | med | TASK-45 | `split` |
+| `wp7-detection` — Detection precision: token-boundary matching + consolidate complexity impls | TASK-48 | — | M | med | TASK-45 | `fix+test` |
+| `wp3-plugin-paths` — Plugin-relative path resolution (skills + hooks work outside the source repo) | TASK-49 | — | L | med | — | `fix+test` |
+| `wp10-multiclaude` — Multi-Claude reliability: repair correctness bugs and gate experimental status honestly | TASK-25 | — | L | med | — | `fix+test` |
+| `wp11-python-misc` — Misc Python correctness fixes | TASK-51 | — | M | low | — | `fix+test` |
+| `wp9-docs-config` — Docs & config drift cleanup | TASK-52 | — | M | low | TASK-44 | `fix+test` |
+
+## Phases
+
+### Phase 1: Phase 1 — Establish the gate + batch zero-dependency quick wins
+
+**Work-packages**: TASK-43, TASK-50, TASK-44
+
+Stand up the CI test runner and pre-publish validation gate (keystone) so all later work is verifiable, and concurrently land the independent low-risk wins. wp8 is doc-only skill-template trimming (no hooks, no manifest, no graph) and wp2 fixes the inverted/dead version logic and adds the bump script — both have no dependsOn and wp2 is a prerequisite for wp9's SOP rewrite. Running them now removes the false generator/template references and the inverted version_lt before any release flows through the new gate. Note ownership: wp8 owns only the nav-stats v3.5.0 string while wp3 (Phase 3) owns the nav-stats cwd-path fix in the same file — coordinate to avoid a collision.
+
+**Exit criterion**: test.yml runs the 233 unit tests on push/PR and the release.yml validate job (--check-all, --verify-hook-paths, --verify-tag, tag==manifest) passes green against v6.15.6 with `release` set to needs: validate; `make test` runs the same 233 tests; every functions/templates/examples path in backend-endpoint/frontend-component SKILL.md resolves to a real file; version_lt reports 6.15.4<6.15.5 true and scripts/bump-version.sh updates all five version locations with release_validator --check-version exiting 0.
+
+### Phase 2: Phase 2 — Test coverage for the surfaces about to be edited
+
+**Work-packages**: TASK-45
+
+wp4 depends on wp1 (its new hook/scorer/graph tests need the CI per-dir runner to execute automatically and to be protected from regression). It must land before the riskier behavioral fixes in Phase 3 because it characterizes the two exit-2 blocking hooks, the compact round-trip, the untested scorers, and adds corruption guards to the graph/profile loaders — establishing the safety net those fixes lean on. It also performs the discovery hygiene (renaming the two mis-named non-test files) that keeps whole-repo discovery clean for everything after.
+
+**Exit criterion**: `python -m unittest discover -s hooks -p test_*.py` passes with the 4 new hook test files; graph_manager.load_graph and profile_manager.load_profile return empty structures (not raise) on corrupt JSON with tests asserting it; the two former mis-named test files no longer match the discovery glob and all SKILL.md/import references are updated; whole-repo discovery collects without ImportError.
+
+### Phase 3: Phase 3 — Behavioral fixes guarded by Phase 2 tests
+
+**Work-packages**: TASK-46, TASK-47, TASK-48
+
+wp5 (hook correctness/safety), wp6 (knowledge-graph integrity + maintenance wiring), and wp7 (detection precision) all declare dependsOn wp4 so their changes land against existing coverage. These touch the highest-consequence runtime surfaces: the published plugin.json manifest (wp5 token_monitor retirement), the SessionStart blocking-budget hook (wp5 auto-update decouple), git-tracked graph data (wp6 dedup/dangling repair), and the exit-2 enforcer's input (wp7 detection boundaries). Running them after wp4 means the blocking-hook and graph behavior is regression-checked. wp6 is recommended split (data-repair track A vs decay-wiring track B) and can be staged within the phase. Path-overlap note: wp5 explicitly defers the nav_session_start CLAUDE_PROJECT_ROOT→DIR one-liner to wp3 (Phase 4) to avoid a double edit on _project_root.
+
+**Exit criterion**: plugin.json contains no token_monitor reference and still parses with nav_task_graph_sync+nav_profile_sync intact; graph_maintenance --action health reports 0 duplicate edges, 0 dangling edges, 0 out-of-range confidences (852→682 edges, 6 dangling removed, mem-026=0.9); detect_workflow('document everything we discussed') returns loop_mode=False while 'run until done' still triggers; all Phase 2 hook tests still pass.
+
+### Phase 4: Phase 4 — Independent script tracks + path resolution (parallelizable)
+
+**Work-packages**: TASK-49, TASK-25, TASK-51
+
+wp3 (plugin-relative path resolution), wp10 (multi-Claude reliability), and wp11 (misc Python) carry no dependsOn edges and touch disjoint surfaces, so they run in parallel for throughput. wp3 is placed here so it can absorb the deferred nav_session_start CLAUDE_PROJECT_ROOT→DIR change from wp5 and the nav-stats cwd-path fix that wp8 left to it, after the hook tests (wp4) exist to confirm the workflow_enforcer block/no-block invariant survives the stdin refactor — its acceptance criteria explicitly require wp4's tests to still pass. wp10 and wp11 are self-contained (scripts/ and skill helpers respectively) and need only their own stub/unit tests.
+
+**Exit criterion**: No bare `python3 skills/` or `bash scripts/` invocations remain in any SKILL.md and helpers resolve from a non-repo cwd with CLAUDE_PLUGIN_DIR unset; nav_session_start uses CLAUDE_PROJECT_DIR; multi-Claude wait_for_file honors its timeout arg, retry re-invokes stubbed claude, APPROVED gate is anchored, git add . is scoped, and shellcheck passes; all six misc Python fixes have passing test_*.py and existing hook tests from wp4 still pass.
+
+### Phase 5: Phase 5 — Docs & config reconciliation
+
+**Work-packages**: TASK-52
+
+wp9 declares dependsOn wp2 because its version-management SOP rewrite, the config_migrator VERSION_CONFIGS extension, and the bump-checklist reconciliation must reflect wp2's bump-version.sh, the releases/ canonical path, and the corrected version-tooling reality. It lands last so it can also reflect the shipped state of every prior phase (eight hooks after wp5's token_monitor retirement, the real skill set, the corrected manifests) and stop the docs drifting against decisions still in flight.
+
+**Exit criterion**: README hardcodes no skill count; CLAUDE.md sample shows 6.15.6 and ~7k tokens with /nav:update-doc removed; config_migrator seeds all v5.x/v6.x feature + lifecycle-hook blocks idempotently (regression test passes); version-management.md lists only real locations and its embedded audit script exits 0 at v6.15.6; neither manifest contains aleks@example.com; both manifests and .nav-config.json still json.load cleanly.
+
+## Critical Path
+
+`TASK-43 → TASK-45 → TASK-47`
+
+## Quick Wins (batch immediately)
+
+- wp8-skill-templates
+- wp2-version-tooling (HIGH version_lt one-line inversion fix + test)
+- wp11-python-misc (task_id_generator regex one-liner, release_validator _strip_dot_slash helper, profile_manager add_goal name guard)
+- wp5-hook-safety (token_monitor retirement + plugin.json/README ~30min, highest-value single edit; workflow_enforcer ImportError stderr one-liner)
+- wp7-detection (delete dead complexity_scorer.py; code_analyzer [a-z]+skip-set 'm' fix)
+
+## Sequencing Notes & File-Overlap Conflicts
+
+Dependency edges respected exactly as declared: wp4→wp1; wp5/wp6/wp7→wp4; wp9→wp2; wp1/wp2/wp3/wp8/wp10/wp11 have no deps. Longest chain is wp1→wp4→{wp5|wp6|wp7} at depth 3 (criticalPath picks wp6 as the deepest/heaviest tail since it is L-effort, split-recommended, and mutates git-tracked data). FILE-OVERLAP CONFLICTS to coordinate: (1) hooks/nav_session_start.py — wp5 (auto-update decouple, _section_auto_update) and wp3 (CLAUDE_PROJECT_ROOT→DIR at line 60) both edit it; wp5 explicitly cedes the line-60 one-liner to wp3, so do the wp5 edits first (Phase 3) then wp3's single-token fix (Phase 4) to avoid a merge collision on _project_root. wp6's OPTIONAL decay-wiring also targets this hook — keep it strictly read-only and do it within wp6 only after wp5's _section_auto_update rewrite settles. (2) skills/nav-stats/SKILL.md — wp8 owns ONLY the 'v3.5.0+' string (line 48), wp3 owns the cwd-relative scripts/session-stats.sh path (lines 46/53/72); these are different lines, batch into one editing pass if wp3 and wp8 run close together. (3) skills/frontend-component/SKILL.md — wp4 renames test_generator.py→file_generator.py (updates refs) and wp8/wp3 also edit this file's template/path references; sequence wp4's rename before wp3/wp8 touch the same file or grep-update jointly. (4) release_validator.py — wp1 adds --verify-hook-paths + tag-vs-version, wp2 implements the --check-version dispatch branch, wp11 adds _strip_dot_slash; all three edit the same file across phases — land wp1's additions first (Phase 1), wp2's --check-version same phase (they are interdependent: wp1's gate CALLS wp2's --check-version), and wp11's lstrip helper can ride either. wp2 and wp1 are effectively co-required in Phase 1 since wp1's tag==manifest assertion depends on wp2 wiring --check-version. DEFER candidates: wp6 track B (decay/staleness wiring) may be deferred to a follow-up if mutation-on-session-start risk is judged too high this pass — the spec's fallback is to mark decay/staleness experimental in config+SKILL.md rather than wire it; wp10's full single-impl complexity-scorer merge is explicitly out of scope (wp7 deletes the dead complexity_scorer.py but defers merging workflow_detector.calculate_complexity into complexity_detector to a separate risk-managed WP because it would change enforcer block thresholds). wp10 and wp11 can start any time (no deps) but are slotted into Phase 4 to keep the critical path uncluttered; pull them earlier if parallel capacity exists.
+
+## Open Gap
+
+- **Security re-sweep (wp12) not completed** — the audit's security dimension and its plan agent both failed to return structured output. Injection / auto-update supply-chain / read-guard-bypass review is still owed before this roadmap is considered complete.
+
+## Refs
+
+- Per-WP tasks: TASK-43 (ci-gate), TASK-44 (version-tooling), TASK-45 (hook-tests), TASK-46 (hook-safety), TASK-47 (kg-integrity), TASK-48 (detection), TASK-49 (plugin-paths), TASK-50 (skill-templates), TASK-51 (python-misc), TASK-52 (docs-config)
+- wp10 (multi-Claude) → **TASK-25** (existing)
+- Audit backlog memory: `project_audit_backlog_2026_06`

--- a/.agent/tasks/TASK-43-ci-gate.md
+++ b/.agent/tasks/TASK-43-ci-gate.md
@@ -1,6 +1,6 @@
 # TASK-43: CI test + pre-publish validation gate
 
-**Status**: 📋 Planned
+**Status**: ✅ Implemented (CI run pending branch push) — 2026-06-02
 **Created**: 2026-06-02
 **Work-package**: `wp1-ci-gate`
 **Phase**: 1 — Gate + zero-dep quick wins

--- a/.agent/tasks/TASK-43-ci-gate.md
+++ b/.agent/tasks/TASK-43-ci-gate.md
@@ -1,0 +1,80 @@
+# TASK-43: CI test + pre-publish validation gate
+
+**Status**: 📋 Planned
+**Created**: 2026-06-02
+**Work-package**: `wp1-ci-gate`
+**Phase**: 1 — Gate + zero-dep quick wins
+**Priority**: High
+**Effort**: M — ~half-day. The test-discovery loop and YAML are mechanical (~half done already by knowing the 6 dirs and 233 count). The two validator additions are small, self-contained Python functions in an existing well-structured file (~40-60 lines + a couple of unit tests for the new functions). Main time sink is iterating on YAML in CI (tag-trigger job is awkward to test locally; can dry-run the validator commands locally but the workflow wiring needs a throwaway tag push or `act` to fully verify).
+**Risk**: med — No hook code or graph data is touched, so runtime user impact is nil. The real risk is the gate itself: an over-strict or buggy assertion could block ALL future releases (release.yml is the only publish path, fires on `v*` tag push). Mitigations: keep the test job on push/PR (non-blocking to release) initially, add the validate job as `needs:` only after the validator commands are confirmed green against the current clean v6.15.6 tree (verified locally: --check-all passed=True, --verify-hooks 18/18, all 5 versions=6.15.6). The new --verify-hook-paths must parse the `${CLAUDE_PLUGIN_DIR:-...}/hooks/<name>.py` command form (verified shape in plugin.json) — a sloppy regex could false-positive and wedge releases.
+**Depends on**: none
+**Recommendation**: `fix+test`
+**Source**: audit `wf_0dc1b9ce-7d8` → plan `wf_187896bb-5af`; roadmap in TASK-42
+
+---
+
+## Summary
+
+Add a GitHub Actions test job (runs all 233 existing unit tests) plus a pre-publish validation gate that blocks the release if any plugin.json hook command path is missing from hooks/, any of the 5 version files disagree, or the pushed tag version does not equal the manifest version — the exact regression that shipped in v6.15.5 and was hotfixed in v6.15.6.
+
+## Findings Addressed
+
+- release.yml publishes with zero pre-publish validation: no version-consistency check, no tag-vs-plugin.json match, no release_validator/test run (.github/workflows/release.yml:11-108)
+- CI (release.yml) runs NO tests — the 233 passing unit tests never execute automatically (.github/workflows/release.yml:1-125)
+
+**Already resolved in v6.15.6** (excluded from this work):
+- ~~The CRITICAL finding (deleted nav_commit_reminder.py still registered in plugin.json PostToolUse:Bash) was removed and version refs synced in v6.15.6 (plugin.json now registers 9 hooks, all resolving to existing files; DEVELOPMENT-README corrected). This WP adds the automated gate so the class of regression cannot recur, but the specific dead-hook block is already gone — verified: release_validator --verify-hooks reports 18/18 and all 5 version files read 6.15.6.~~
+
+## Implementation
+
+Two pieces, both grounded in verified code.
+
+(1) TEST JOB. The Makefile `test` target (Makefile:16-22) is a sham — it only `exec`s status_generator.py and never touches the 13 test_*.py files; `unittest discover -s skills` from repo root finds 0 tests because every test file does `sys.path.insert(0, str(Path(__file__).parent))` and imports its sibling module by bare name (e.g. test_exit_gate.py:11 `from exit_gate import ...`). They must be discovered per-directory. Verified: running `python3 -m unittest discover -p "test_*.py"` from each of the 6 genuine unittest dirs sums to EXACTLY 233 tests, all OK: nav-upgrade/functions (7), nav-sync-claude/functions (7), nav-simplify/scripts (20), nav-workflow/functions (101 = 3 files), nav-init/functions (11), nav-loop/functions (87 = 4 files). Two files named test_*.py are NOT unittest and must be excluded: skills/frontend-component/functions/test_generator.py (an argparse CLI generator) and skills/product-design/functions/test_mcp_connection.py (a live Figma MCP probe needing a venv). Implementation: add .github/workflows/test.yml (on push + pull_request) that loops over the 6 dirs (or globs functions/scripts dirs minus the venv and the two non-test files) and runs `python3 -m unittest discover -p "test_*.py"` in each via a subshell, failing on first non-OK. Provide a `make test` rewrite mirroring the same loop so local and CI agree.
+
+(2) PRE-PUBLISH GATE. Add a `validate` job to release.yml that runs BEFORE the existing `release` job (make `release` need: `validate`). It runs the existing skills/nav-release/functions/release_validator.py plus two NEW assertions that currently do not exist:
+  (a) HOOK-PATH RESOLUTION (the keystone). verify_hooks() (release_validator.py:316-394) smoke-tests hook commands at runtime but does NOT statically assert the file exists, and crucially mis-classifies the v6.15.6 signature: a missing-file PostToolUse/Bash hook exits 2 with stderr, but is_silent_failure (line 365-370) is only True for events in HOOK_EMITS_PAYLOAD={SessionStart,PreCompact,PostCompact}; PostToolUse is silent-by-design, so it lands in `passed` (verified by reproducing the classifier — returns PASS). Add a new function (and `--verify-hook-paths` flag) that, for every hook command in plugin.json, extracts the `hooks/<name>.py` basename from the command string and asserts (root / "hooks" / name).exists(), failing with the offending command. This is literally the follow-up the v6.15.6 marketplace.json breaking_changes note prescribes.
+  (b) TAG-VS-MANIFEST. release_validator already has check_version_consistency() (line 128-178) reading all 5 files (plugin.json, marketplace.json metadata.version, CLAUDE.md, README.md badge, .nav-config.json) and --verify-tag (line 431-448) checks only SKILL.md presence in the tag — neither compares the pushed tag to the manifest. Note --check-version is declared as an arg (line 400) but has NO dispatch branch in main(); wire it (or add `--assert-tag-version`) to compare the GITHUB_REF-stripped version against every value from check_version_consistency() and fail on any mismatch. The gate shell strips `refs/tags/v` exactly as release.yml:25 already does.
+
+The validate job: checkout (fetch-depth: 0, needed for --verify-tag git ls-tree), then run `release_validator.py --check-all`, `--verify-hook-paths`, `--verify-tag "$TAG"`, and the tag==version assertion; any non-zero exit fails the workflow before any `gh release create` runs.
+
+### Files
+
+| File | Change |
+| --- | --- |
+| `.github/workflows/test.yml` | NEW: on push/PR, loop the 6 genuine unittest dirs and run `python3 -m unittest discover -p test_*.py` in each, excluding the two non-unittest test_*.py files and the product-design venv |
+| `.github/workflows/release.yml` | Add a `validate` job (checkout fetch-depth 0) running release_validator --check-all/--verify-hook-paths/--verify-tag plus tag==manifest version assertion; make existing `release` job `needs: validate` |
+| `skills/nav-release/functions/release_validator.py` | Add verify_hook_paths() + `--verify-hook-paths` flag (static hooks/<name>.py existence per plugin.json command); wire the declared-but-undispatched --check-version (or add --assert-tag-version) to compare a tag version against all check_version_consistency() values |
+| `Makefile` | Rewrite the sham `test` target (currently only exec's one module) to run the same per-dir unittest discovery loop as test.yml so local == CI |
+
+## Acceptance Criteria
+
+- [ ] test.yml runs on push and PR and executes exactly the 233 genuine unit tests (6 dirs), excluding skills/frontend-component/functions/test_generator.py and skills/product-design/functions/test_mcp_connection.py; the job fails if any test fails
+- [ ] `make test` runs the same 233 tests locally and exits non-zero on failure (no longer a no-op exec of status_generator.py)
+- [ ] release_validator.py --verify-hook-paths exits 0 on current main and exits non-zero with the offending command when a plugin.json hook command references a hooks/<name>.py that does not exist (regression-test: re-add a nav_commit_reminder.py PostToolUse:Bash block to a temp manifest -> non-zero)
+- [ ] release_validator.py tag-vs-version mode exits 0 when the tag (e.g. v6.15.6) matches all 5 version files and non-zero when any of plugin.json/marketplace.json/CLAUDE.md/README.md/.nav-config.json disagrees with the tag
+- [ ] release.yml `release` job has `needs: validate`; the validate job runs --check-all, --verify-hook-paths, --verify-tag, and the tag==version assertion, and no `gh release create` step can run if any fails
+- [ ] New validator functions have unit tests under skills/nav-release/functions/test_release_validator.py discoverable by the same per-dir runner (raising the suite past 233)
+
+## Technical Decisions
+
+- **Recommendation**: `fix+test`. No hook code or graph data is touched, so runtime user impact is nil. The real risk is the gate itself: an over-strict or buggy assertion could block ALL future releases (release.yml is the only publish path, fires on `v*` tag push). Mitigations: keep the test job on push/PR (non-blocking to release) initially, add the validate job as `needs:` only after the validator commands are confirmed green against the current clean v6.15.6 tree (verified locally: --check-all passed=True, --verify-hooks 18/18, all 5 versions=6.15.6). The new --verify-hook-paths must parse the `${CLAUDE_PLUGIN_DIR:-...}/hooks/<name>.py` command form (verified shape in plugin.json) — a sloppy regex could false-positive and wedge releases.
+
+## Out of Scope
+
+- Findings outside this work-package's listed scope (see TASK-42 roadmap for the full map).
+
+## Refs
+
+- TASK-42 — Audit Remediation Roadmap (umbrella)
+
+## Verify
+
+```bash
+# See Acceptance Criteria; run the relevant tests/validators before marking done.
+```
+
+## Done
+
+- [ ] All acceptance criteria checked
+- [ ] Tests pass in CI (once TASK-43 gate exists)
+- [ ] Committed + roadmap (TASK-42) status updated

--- a/.agent/tasks/TASK-44-version-tooling.md
+++ b/.agent/tasks/TASK-44-version-tooling.md
@@ -1,0 +1,86 @@
+# TASK-44: Version & release tooling correctness
+
+**Status**: 📋 Planned
+**Created**: 2026-06-02
+**Work-package**: `wp2-version-tooling`
+**Phase**: 1 — Gate + zero-dep quick wins
+**Priority**: High
+**Effort**: L — L (1-2d). The HIGH version_lt fix is S on its own (one-line logic + test). But the package spans 3 scripts + 1 Python module + 2 doc files + a new bump script + 2 new test files + migrating 4 stray release-notes files. The version_detector rewrite is bounded (logic already proven in auto_updater.py — copy/adapt), the --check-version branch is ~15 lines, and the bump script is straightforward sed/jq across five exact locations I verified. Doc rewrite of SOP Step 3/4 plus checklist is the bulk of the prose work.
+**Risk**: med — release.yml is a published, tag-triggered workflow — a wrong edit to pre-release detection silently mismarks every future release; the change is low-LOC but must be tested against a dummy tag. version_lt and version_detector feed the auto-update path users hit on every session start, so a regression could trigger spurious reinstalls or suppress real updates — mitigated by unit tests. No KG/graph mutation, no blocking hook involved. bump-version.sh writes five repo files but is run manually, not in a hook.
+**Depends on**: none
+**Recommendation**: `fix+test`
+**Source**: audit `wf_0dc1b9ce-7d8` → plan `wf_187896bb-5af`; roadmap in TASK-42
+
+---
+
+## Summary
+
+Fix the inverted/dead version-comparison and detection logic and the documented-vs-automated release-path drift so Navigator's upgrade and release tooling reports the right answer and the SOP matches the CI workflow.
+
+## Findings Addressed
+
+- HIGH: version_lt() in scripts/check-version.sh is logically inverted (reports 'up to date' when update available)
+- MED: version_detector.get_current_version() parses wrong line of `claude plugin list` (single-line regex vs multi-line block)
+- MED: version_detector get_plugin_json_version() fallback paths don't match version-keyed cache layout, returns None
+- MED: release_validator.py --check-version parsed but never used; wrong version still exits 0
+- MED: SOP creates release notes at repo root but release.yml canonical path is releases/
+- MED: multi-file version bump is fully manual/vim-driven, no bump script (SOP flags this gap)
+- LOW: release.yml greps 'Experimental' (capital) but marketplace.json only has lowercase 'experimental', and that token lives in a historical changelog array entry not a status field — detection can never fire correctly
+- LOW: check-version.sh masks command exit code via `local var=$(cmd)`, making the network-failure guard unreliable
+- LOW: release_validator reads marketplace .metadata.version while post-install.sh greps first "version" match — they agree only by coincidence (no top-level version exists)
+
+**Already resolved in v6.15.6** (excluded from this work):
+- ~~v6.15.6 removed the dead nav_commit_reminder.py hook block and synced versions — none of the wp2 findings were resolved by that change; all nine remain open in the current tree (verified plugin.json/marketplace/README/CLAUDE.md/.nav-config all read 6.15.6 but the logic bugs are untouched)~~
+
+## Implementation
+
+Fix in four grounded groups. (1) HIGH version_lt: rewrite scripts/check-version.sh:64-75 to return true only when v1<v2 AND v1!=v2 — `[ "$(printf '%s\n%s' "$v1" "$v2" | sort -V | head -1)" = "$v1" ] && [ "$v1" != "$v2" ]`. Verified empirically the current `sort -V -C || return 0` is inverted (6.15.4<6.15.5 -> FALSE). Also fix the :90-92 exit-code mask: split `local latest_version; latest_version=$(get_latest_version)` so `$?` is meaningful. (2) version_detector.py: replace get_current_version() :38-45 single-line regex with the proven multi-line block-scan from skills/nav-start/functions/auto_updater.py:44-64 (set in_navigator_block on the `@`/`❯` line, match `Version:\s*v?(\d+\.\d+\.\d+)` on following lines, reset on next `❯`); replace get_plugin_json_version() :57-73 static paths with a glob of `~/.claude/plugins/cache/*/navigator/*/.claude-plugin/plugin.json` picking the highest version dir (mirror the existing sort-by-`re.findall(r'\d+')` logic in release_validator.py:308-312). (3) release_validator.py: implement the --check-version branch in main() after :453 — compare each value from check_version_consistency() to args.check_version, print mismatches, return 1 on any mismatch or NOT_FOUND; this is what wp1's CI gate will call. Optionally standardize marketplace access on .metadata.version everywhere and assert it equals plugin.json top-level (post-install.sh:9 already resolves to metadata.version since no top-level key exists). (4) release.yml:59-64 + SOP: make pre-release detection rely on tag suffixes only (drop the marketplace grep — the lowercase 'experimental' token is a historical changelog entry, not a status field, so any grep false-fires) OR add a real `metadata.status` field and grep that; align the SOP inline comment + Step 9 text. Add scripts/bump-version.sh <version> updating all five verified locations (plugin.json:3, marketplace.json metadata.version:10, README badge:8 `version-X-blue`, CLAUDE.md:967 `**Navigator Version**:`, .agent/.nav-config.json:2) then running release_validator --check-version; rewrite SOP Step 3 (:96-127), Step 4 path (:132), README example (:276), checklist (:603) to use releases/ and the bump script; migrate the 4 stray root RELEASE-NOTES files (v5.3.0/v5.4.0/v5.5.0/v6.1.0) into releases/.
+
+### Files
+
+| File | Change |
+| --- | --- |
+| `scripts/check-version.sh` | Rewrite version_lt() (lines 64-75) to non-inverted v1<v2 logic; split local-assignment at :90-92 so $? guard works |
+| `skills/nav-upgrade/functions/version_detector.py` | Replace get_current_version() block-scan (38-45) with auto_updater's multi-line logic; replace get_plugin_json_version() fallback paths (57-73) with cache-glob of ~/.claude/plugins/cache/*/navigator/*/.claude-plugin/plugin.json |
+| `skills/nav-release/functions/release_validator.py` | Implement the --check-version branch in main() (~line 453): compare each detected version to the argument, exit 1 on mismatch/NOT_FOUND |
+| `.github/workflows/release.yml` | Fix pre-release detection (lines 59-64): drop the false-firing marketplace grep in favor of tag-suffix-only, or grep a real status field |
+| `.agent/sops/development/complete-release-workflow.md` | Update Step 3 (96-127) to reference scripts/bump-version.sh, Step 4 (132)/README example (276)/checklist (603) to use releases/ path; align pre-release-detection text (374,392) |
+| `scripts/bump-version.sh` | NEW: bump all five version locations from a single arg and run release_validator --check-version |
+| `tests/test-check-version.sh` | NEW: unit test asserting version_lt 6.15.4<6.15.5 true, equal false, 6.16.0<6.15.5 false |
+| `skills/nav-upgrade/functions/test_version_detector.py` | NEW: tests for block-scan parsing of `claude plugin list` fixture and cache-glob fallback (mirrors existing skills/*/functions/test_*.py harness) |
+| `releases/RELEASE-NOTES-v5.3.0.md` | Migrate stray root-level file into releases/ (also v5.4.0, v5.5.0, v6.1.0) |
+
+## Acceptance Criteria
+
+- [ ] tests/test-check-version.sh asserts: version_lt 6.15.4 6.15.5 -> true (exit 0), version_lt 6.15.5 6.15.5 -> false, version_lt 6.16.0 6.15.5 -> false; runs green
+- [ ] running scripts/check-version.sh with a real older local version against a newer GitHub release prints 'Update Available' and returns 1 (not 'up to date')
+- [ ] test_version_detector.py: get_current_version() returns the version from a multi-line `claude plugin list` fixture; get_plugin_json_version() resolves a version from a simulated ~/.claude/plugins/cache/*/navigator/<v>/.claude-plugin/plugin.json tree
+- [ ] release_validator.py --check-version 9.9.9 exits non-zero with a per-file mismatch report; --check-version <actual> exits 0
+- [ ] pushing a non-suffixed tag yields is_prerelease=false and an alpha/beta/rc tag yields true; the marketplace historical 'experimental' changelog entry no longer forces every release to pre-release
+- [ ] scripts/bump-version.sh 6.16.0 updates plugin.json:3, marketplace.json metadata.version:10, README badge:8, CLAUDE.md:967, .agent/.nav-config.json:2, then release_validator --check-version 6.16.0 exits 0
+- [ ] SOP Step 3/4, README example, and checklist all reference releases/ and scripts/bump-version.sh; no remaining instruction to write notes at repo root
+- [ ] the 4 stray root RELEASE-NOTES files are moved under releases/ (git mv) so release.yml's FALLBACK branch is only legacy-compat
+
+## Technical Decisions
+
+- **Recommendation**: `fix+test`. release.yml is a published, tag-triggered workflow — a wrong edit to pre-release detection silently mismarks every future release; the change is low-LOC but must be tested against a dummy tag. version_lt and version_detector feed the auto-update path users hit on every session start, so a regression could trigger spurious reinstalls or suppress real updates — mitigated by unit tests. No KG/graph mutation, no blocking hook involved. bump-version.sh writes five repo files but is run manually, not in a hook.
+
+## Out of Scope
+
+- Findings outside this work-package's listed scope (see TASK-42 roadmap for the full map).
+
+## Refs
+
+- TASK-42 — Audit Remediation Roadmap (umbrella)
+
+## Verify
+
+```bash
+# See Acceptance Criteria; run the relevant tests/validators before marking done.
+```
+
+## Done
+
+- [ ] All acceptance criteria checked
+- [ ] Tests pass in CI (once TASK-43 gate exists)
+- [ ] Committed + roadmap (TASK-42) status updated

--- a/.agent/tasks/TASK-45-hook-tests.md
+++ b/.agent/tasks/TASK-45-hook-tests.md
@@ -1,0 +1,116 @@
+# TASK-45: Test coverage for hooks & destructive/blocking paths
+
+**Status**: 📋 Planned
+**Created**: 2026-06-02
+**Work-package**: `wp4-hook-tests`
+**Phase**: 2 — Test coverage
+**Priority**: High
+**Effort**: L — ~1-2 days. 11 new test files. The two blocking-hook suites and the compact round-trip carry real complexity: workflow_enforcer needs a tmp-project fixture with a crafted .nav-workflow-state.json and exercises the select.select stdin path; nav_read_guard needs multi-invocation counter-state setup; the compact round-trip threads stdin JSON across pre→post→session_start with a synthetic JSONL transcript. The scorer/graph/profile direct-import tests are quick (mirror the existing test_complexity_detector.py pattern, ~S each). The two corruption-guard edits are trivial (~3 lines each). Renames are mechanical but require grepping SKILL.md for references. No new dependencies — all stdlib unittest.
+**Risk**: med — The two corruption-guard edits touch live load paths for the knowledge graph and ToM profile, but they only ADD a fallback on an already-failing parse (current behavior is an uncaught exception), so they cannot regress a healthy file. The renamed files (test_generator.py, test_mcp_connection.py) are referenced by frontend-component and product-design SKILL.md and possibly by sibling imports — must grep and update all references or the skills break at runtime; this is the main risk surface. Tests themselves are additive (no production behavior change). The blocking hooks (nav_read_guard exit 2, workflow_enforcer exit 2) are exercised only via subprocess against tmp projects, never the real .agent/ — no risk to the running session. No published-manifest change.
+**Depends on**: TASK-43 (wp1-ci-gate)
+**Recommendation**: `fix+test`
+**Source**: audit `wf_0dc1b9ce-7d8` → plan `wf_187896bb-5af`; roadmap in TASK-42
+
+---
+
+## Summary
+
+Add a stdlib-unittest suite covering all 9 hooks (especially the two exit-2 blockers and the PreCompact/PostCompact marker round-trip), the untested workflow_detector/complexity_scorer scorers, and corruption-guarded graph/profile loaders, and stop the two mis-named non-test files from poisoning test discovery.
+
+## Findings Addressed
+
+- All 9 hooks (2,026 lines) have ZERO tests including two exit-2 blockers (nav_read_guard, workflow_enforcer)
+- workflow_detector.calculate_complexity / detect_loop_trigger / detect_workflow untested while near-duplicate complexity_detector is heavily tested
+- graph_manager.load_graph uses bare json.load with no corruption guard and has no tests
+- profile_manager.load_profile uses bare json.load with no corruption guard and has no tests
+- auto_updater.py destructive uninstall/reinstall path + version comparison + plugin-list parsing untested
+- complexity_scorer.py (separate from tested complexity_detector) untested
+- Two files named like tests are not tests (frontend-component/functions/test_generator.py, product-design/functions/test_mcp_connection.py) — poison test discovery
+- nav_pre_compact / nav_post_compact marker round-trip has no test despite being the compact-survival mechanism
+
+## Implementation
+
+All tests use stdlib `unittest` (pytest is NOT installed; Python 3.14 in env, existing suites like skills/nav-workflow/functions/test_complexity_detector.py run via `python -m unittest`). Two test styles, both already proven in-repo: (1) direct import of the module-under-test via `sys.path.insert(0, str(Path(__file__).parent))`, (2) subprocess + piped stdin JSON for hooks.
+
+HOOKS (new files hooks/test_*.py):
+- test_workflow_enforcer.py: invoke hooks/workflow_enforcer.py via subprocess with `input=json.dumps({"prompt": ...})`, `cwd=<tmp project>`. Assert (a) plain prompt → exit 0, prints WORKFLOW CHECK block; (b) loop-trigger prompt with NO state file → exit 0 (soft warn, Phase-1 safety per lines 13/152-174); (c) loop-trigger prompt + `.agent/.nav-workflow-state.json` with `last_turn.check_shown=false` + default strict_block → exit 2 and stderr contains `<nav-workflow-block>` sentinel (lines 146-203); (d) same but `strict_block=false` in .nav-config.json → exit 0; (e) `PILOT_EXECUTOR=1` env → exit 0 immediately (line 126); (f) strip_block_messages: a prompt already containing the sentinel block does not re-trigger (mem-034 regression, line 57-69).
+- test_nav_read_guard.py: subprocess with stdin `{"tool_name":"Read","tool_input":{"file_path":...},"cwd":...,"session_id":...}`. Assert (a) non-Read tool → exit 0; (b) path outside .agent/ → exit 0; (c) allowlisted file (DEVELOPMENT-README.md) never counts; (d) drive counter to warn_threshold then escalate_threshold via repeated invocations sharing one session_id+counter file → exit 2 at escalate with `<nav-read-guard-block>` (lines 241-243); (e) `strict_block=false` → exit 0 even past threshold (line 244); (f) session_id change resets counter (lines 133-136); (g) no `.agent/` dir → silent exit 0 (line 202).
+- test_compact_roundtrip.py (covers nav_pre_compact + nav_post_compact + surfacing): build a tmp project with `.agent/`, write a synthetic JSONL transcript file. Run nav_pre_compact.py with stdin `{"cwd":..,"transcript_path":..,"session_id":..,"trigger":"manual"}`; assert a `before-compact-manual-*.md` marker AND `.context-markers/.active` are written (lines 300-309). Then run nav_post_compact.py with stdin `{"cwd":..,"compact_summary":"SUMMARY-SENTINEL"}`; assert the `## Compact Summary (Claude Code)` section is appended to the same marker (lines 97-103). Then call nav_session_start.py `_section_active_marker` (import or subprocess) and assert it surfaces the marker name (nav_session_start.py:71-88). Also assert PostCompact with missing `.active` is a no-op exit 0 (lines 80-83).
+- test_hooks_smoke.py: parametrized smoke over the remaining hooks (nav_session_start, nav_profile_sync, nav_task_graph_sync, nav_workflow_state, token_monitor): feed minimal valid stdin JSON + a tmp `.agent/` cwd and assert exit 0 and valid/empty stdout (these are non-blocking; goal is import+no-crash + empty-JSON contract). Also feed each hook empty stdin and malformed JSON and assert it still exits 0 (every hook has a `json.JSONDecodeError` guard).
+
+SCORERS (direct-import tests, mirror test_complexity_detector.py):
+- skills/nav-start/functions/test_workflow_detector.py: detect_loop_trigger phrase matching (lines 100-113) incl. case-insensitivity and no-match; calculate_complexity thresholds (high 0.3 / medium 0.2 / low 0.1 / multi-file 0.2, cap 1.0, lines 116-155); detect_workflow dict shape the enforcer reads — keys loop_mode/loop_trigger/task_mode/complexity/recommended_mode (lines 158-187, consumed by workflow_enforcer.py:139-156).
+- skills/nav-start/functions/test_complexity_scorer.py: calculate_score category boundaries trivial/simple/moderate/substantial/complex (lines 170-179), factor breakdown keys, task_mode>=0.5 (lines 181-187).
+
+CORRUPTION GUARDS (code change + tests):
+- skills/nav-graph/functions/graph_manager.py:16-22 — wrap `json.load` in try/except `json.JSONDecodeError` returning `create_empty_graph()`.
+- skills/nav-profile/functions/profile_manager.py:15-21 — wrap `json.load` in try/except returning `{}` (matches existing missing-file contract).
+- test_graph_manager.py: load on missing/corrupt/valid file; add_node/remove_node concept_index consistency (lines 81-124); add_edge dedup (lines 138-145); save_graph→load_graph round-trip via tempfile.
+- test_profile_manager.py: load missing/corrupt; update_preference, add_correction max-20 cap (lines 88-90), add_goal upsert (lines 104-113).
+
+AUTO_UPDATER (mocked, no real plugin ops):
+- skills/nav-start/functions/test_auto_updater.py: unit-test pure functions with no mocking — compare_versions newer/older/equal/uneven-length (lines 89-110); get_current_version parsing by monkeypatching `subprocess.run` to return representative `claude plugin list` stdout (lines 44-64). For reinstall_plugin (lines 177-225), monkeypatch subprocess.run to assert a failed uninstall returns `success:false` WITHOUT calling install (verifies no inconsistent state) and that a failed reinstall is reported. Do NOT execute real `claude plugin` commands.
+
+DISCOVERY HYGIENE (the two mis-named files):
+- Rename skills/frontend-component/functions/test_generator.py → file_generator.py (0 test functions; argparse generator) and update its references in skills/frontend-component/SKILL.md.
+- Rename skills/product-design/functions/test_mcp_connection.py → check_mcp_connection.py (module-level `from figma_mcp_client import` crashes collection) and update product-design/SKILL.md references.
+- Add a discovery convention note (tests are `python -m unittest discover -s <dir> -p 'test_*.py'`); the rename removes the two false positives.
+
+NOTE on running in CI: these are stdlib-unittest files runnable today with `python -m unittest`, but a CI job that auto-discovers and runs them is wp1-ci-gate's deliverable — hence dependsOn wp1.
+
+### Files
+
+| File | Change |
+| --- | --- |
+| `/Users/aleks.petrov/Projects/startups/navigator/hooks/test_workflow_enforcer.py` | NEW: subprocess tests for exit 0 vs exit 2 gate, sentinel stderr, PILOT_EXECUTOR bypass, strip_block_messages regression |
+| `/Users/aleks.petrov/Projects/startups/navigator/hooks/test_nav_read_guard.py` | NEW: subprocess tests for counter increment, warn/escalate thresholds, exit 2 block, strict_block=false, session reset, allowlist |
+| `/Users/aleks.petrov/Projects/startups/navigator/hooks/test_compact_roundtrip.py` | NEW: PreCompact writes marker+.active, PostCompact appends summary, nav_session_start surfaces it, missing-.active no-op |
+| `/Users/aleks.petrov/Projects/startups/navigator/hooks/test_hooks_smoke.py` | NEW: import+no-crash + empty/malformed-stdin exit-0 smoke for nav_session_start, nav_profile_sync, nav_task_graph_sync, nav_workflow_state, token_monitor |
+| `/Users/aleks.petrov/Projects/startups/navigator/skills/nav-start/functions/test_workflow_detector.py` | NEW: detect_loop_trigger, calculate_complexity thresholds, detect_workflow dict-shape contract |
+| `/Users/aleks.petrov/Projects/startups/navigator/skills/nav-start/functions/test_complexity_scorer.py` | NEW: calculate_score category boundaries and factor breakdown |
+| `/Users/aleks.petrov/Projects/startups/navigator/skills/nav-start/functions/test_auto_updater.py` | NEW: compare_versions, get_current_version parsing, reinstall failed-uninstall-no-install safety (subprocess mocked) |
+| `/Users/aleks.petrov/Projects/startups/navigator/skills/nav-graph/functions/graph_manager.py` | EDIT load_graph (lines 16-22): guard json.load with try/except JSONDecodeError → create_empty_graph() |
+| `/Users/aleks.petrov/Projects/startups/navigator/skills/nav-graph/functions/test_graph_manager.py` | NEW: load missing/corrupt/valid, add/remove_node concept-index, edge dedup, save/load round-trip |
+| `/Users/aleks.petrov/Projects/startups/navigator/skills/nav-profile/functions/profile_manager.py` | EDIT load_profile (lines 15-21): guard json.load with try/except JSONDecodeError → {} |
+| `/Users/aleks.petrov/Projects/startups/navigator/skills/nav-profile/functions/test_profile_manager.py` | NEW: load missing/corrupt, update_preference, add_correction 20-cap, add_goal upsert |
+| `/Users/aleks.petrov/Projects/startups/navigator/skills/frontend-component/functions/test_generator.py` | RENAME → file_generator.py (not a test; poisons discovery); update SKILL.md refs |
+| `/Users/aleks.petrov/Projects/startups/navigator/skills/product-design/functions/test_mcp_connection.py` | RENAME → check_mcp_connection.py (not a test; module-level figma import crashes collection); update SKILL.md refs |
+| `/Users/aleks.petrov/Projects/startups/navigator/skills/frontend-component/SKILL.md` | EDIT: update references from test_generator.py to file_generator.py |
+| `/Users/aleks.petrov/Projects/startups/navigator/skills/product-design/SKILL.md` | EDIT: update references from test_mcp_connection.py to check_mcp_connection.py |
+
+## Acceptance Criteria
+
+- [ ] `python -m unittest discover -s hooks -p 'test_*.py'` passes with the 4 new hook test files
+- [ ] test_workflow_enforcer asserts exit 2 + `<nav-workflow-block>` sentinel only when loop trigger AND state check_shown=false AND strict_block=true; exit 0 in all other branches incl. PILOT_EXECUTOR set and missing state file
+- [ ] test_nav_read_guard drives the per-turn counter past escalate_threshold and asserts exit 2 + `<nav-read-guard-block>`, plus exit 0 when strict_block=false and on session_id change
+- [ ] test_compact_roundtrip: PreCompact writes marker + .active, PostCompact appends `## Compact Summary (Claude Code)` containing the injected summary sentinel, nav_session_start _section_active_marker surfaces the marker name, and PostCompact with no .active is a no-op exit 0
+- [ ] graph_manager.load_graph and profile_manager.load_profile return create_empty_graph()/{} on a corrupt JSON file instead of raising, with tests asserting this
+- [ ] test_workflow_detector and test_complexity_scorer cover loop-trigger matching, complexity thresholds/cap, and all five complexity_scorer categories
+- [ ] test_auto_updater covers compare_versions (newer/older/equal/uneven), get_current_version parsing of representative `claude plugin list` output, and reinstall_plugin returning success:false on failed uninstall WITHOUT invoking install — all with subprocess.run mocked (zero real plugin operations)
+- [ ] skills/frontend-component/functions/test_generator.py and skills/product-design/functions/test_mcp_connection.py no longer match the `test_*.py` discovery glob (renamed), and every SKILL.md/import reference to them is updated
+- [ ] Whole-repo discovery `python -m unittest discover -s . -p 'test_*.py'` (excluding venv) collects without ImportError from the two former mis-named files
+
+## Technical Decisions
+
+- **Recommendation**: `fix+test`. The two corruption-guard edits touch live load paths for the knowledge graph and ToM profile, but they only ADD a fallback on an already-failing parse (current behavior is an uncaught exception), so they cannot regress a healthy file. The renamed files (test_generator.py, test_mcp_connection.py) are referenced by frontend-component and product-design SKILL.md and possibly by sibling imports — must grep and update all references or the skills break at runtime; this is the main risk surface. Tests themselves are additive (no production behavior change). The blocking hooks (nav_read_guard exit 2, workflow_enforcer exit 2) are exercised only via subprocess against tmp projects, never the real .agent/ — no risk to the running session. No published-manifest change.
+
+## Out of Scope
+
+- Findings outside this work-package's listed scope (see TASK-42 roadmap for the full map).
+
+## Refs
+
+- TASK-42 — Audit Remediation Roadmap (umbrella)
+- TASK-43 — dependency (`wp1-ci-gate`)
+
+## Verify
+
+```bash
+# See Acceptance Criteria; run the relevant tests/validators before marking done.
+```
+
+## Done
+
+- [ ] All acceptance criteria checked
+- [ ] Tests pass in CI (once TASK-43 gate exists)
+- [ ] Committed + roadmap (TASK-42) status updated

--- a/.agent/tasks/TASK-46-hook-safety.md
+++ b/.agent/tasks/TASK-46-hook-safety.md
@@ -1,0 +1,97 @@
+# TASK-46: Hook correctness & safety fixes (non-path)
+
+**Status**: 📋 Planned
+**Created**: 2026-06-02
+**Work-package**: `wp5-hook-safety`
+**Phase**: 3 — Behavioral fixes (guarded)
+**Priority**: Medium
+**Effort**: M — ~half-day. token_monitor retirement + plugin.json + README is ~30min and the highest-value piece. The auto-update decouple is the most involved (rewrite the parsing branch in _section_auto_update against the --check-drift JSON shape, ~1h incl. manual run). Staleness guard, pre-compact regex (mirrored to marker_compressor), and the enforcer one-liner are each <30min. Bulk of the time is writing the hook tests wp4 will house (subprocess-driven stdin JSON fixtures). All edits are small and localized; no cross-cutting refactor.
+**Risk**: med — Touches the published .claude-plugin/plugin.json manifest that ships to every installed user (same surface as the v6.15.6 critical fix) — removing the token_monitor PostToolUse entry must keep the JSON valid and the remaining two PostToolUse Edit|Write entries intact. nav_session_start.py is a blocking-budget SessionStart hook: the auto-update change reduces risk (read-only vs mutating) but a parsing bug in the --check-drift branch could drop the drift notice (degraded UX, not a crash — _build_payload swallows section exceptions at line 301). The read-counter staleness guard only relaxes blocking, so worst case is a missed bulk-load warning, never a false block. No knowledge-graph data mutation. Requires Claude Code restart to re-register the changed manifest (standard for any plugin.json change).
+**Depends on**: TASK-45 (wp4-hook-tests)
+**Recommendation**: `fix+test`
+**Source**: audit `wf_0dc1b9ce-7d8` → plan `wf_187896bb-5af`; roadmap in TASK-42
+
+---
+
+## Summary
+
+Make Navigator's lifecycle hooks correct and safe by retiring the dead-channel/inaccurate token_monitor, decoupling the mutating plugin-update call from the SessionStart hook budget, and hardening the read-counter, pre-compact heuristics, and workflow_enforcer import fallback.
+
+## Findings Addressed
+
+- SessionStart hook runs a full mutating `claude plugin update` (30s+60s subprocess chain) under a 4s subprocess timeout inside a 10s hook budget (nav_session_start.py:162-195 + auto_updater.py:146-174)
+- token_monitor.py prints user-facing warnings on PostToolUse stdout — a model-silent channel per mem-035, same dead-channel class as the retired nav_commit_reminder probe (token_monitor.py:113-122)
+- token_monitor token estimate counts entire transcript bytes/4 (including pruned tool outputs) against a hardcoded non-configurable 180k TOKEN_LIMIT (token_monitor.py:29,45-57,94)
+- token_monitor.py file mode is 0711 (rwx--x--x), not group/other readable, unlike all sibling hooks 0644/0755
+- Read-counter reset is double-sourced (read_guard resets on session_id change; Stop hook resets to 0) with no staleness guard, so a skipped Stop event can bleed a stale count across turns (nav_read_guard.py:131-145, nav_workflow_state.py:84-108)
+- nav_pre_compact._compress_context scans only the last 200 transcript lines and treats any line containing a file extension as a file path, yielding low-fidelity recovery markers (nav_pre_compact.py:125-153)
+- workflow_enforcer falls back to a stub detect_workflow on ImportError with no diagnostic, silently disabling all workflow detection (workflow_enforcer.py:46-54)
+
+**Already resolved in v6.15.6** (excluded from this work):
+- ~~plugin.json registered the deleted nav_commit_reminder.py PostToolUse(Bash) hook — removed in v6.15.6; the PostToolUse block now lists only token_monitor (Edit|Write|Bash) + nav_task_graph_sync + nav_profile_sync (Edit|Write), verified at .claude-plugin/plugin.json:128-159~~
+- ~~DEVELOPMENT-README.md corrected from ten to nine hooks with the nav_commit_reminder row removed and version refs synced to 6.15.6 (v6.15.6)~~
+
+## Implementation
+
+Five independent edits, sequenced low-risk first.
+
+1) token_monitor retirement (primary). mem-035 (.agent/knowledge/memories/pitfalls/mem-035.md:37) proves PostToolUse has no model-visible channel — token_monitor.py:113-122 print() to stdout is dead, exactly like the retired nav_commit_reminder probe. The estimate (token_monitor.py:45-57,94) reads the whole transcript file (`len(content)//4`) including tool outputs already pruned from context, against hardcoded TOKEN_LIMIT=180000 (line 29). Recommend RETIRE: delete the PostToolUse(Edit|Write|Bash) entry at plugin.json:128-138, delete hooks/token_monitor.py, and update the DEVELOPMENT-README.md hook table (currently labels it "(legacy)" at the 9th row) to "eight hooks". Keep token_monitor's basename in skills/nav-upgrade/functions/migrate_hooks_out_of_settings.py:56 NAV_HOOK_BASENAMES so existing users' settings.json entries still get cleaned up. This single change also resolves the 0711-perms finding (file gone) and the inaccurate-estimate finding (hook gone). If product wants to keep a context-pressure signal, the fallback is: emit `{}` on stdout, move text to stderr, make TOKEN_LIMIT a config key, and subtract a fixed JSON-envelope factor — but mem-035 makes retirement the honest call.
+
+2) Decouple SessionStart auto-update. nav_session_start.py:_section_auto_update (162-195) invokes auto_updater.py with NO args under timeout=4, which triggers auto_updater.auto_update() — chaining refresh_marketplace (30s, line 132) + update_plugin_via_claude (60s, line 162) + possible reinstall (line 177). Change the subprocess call (line 170) to `[sys.executable, str(updater), "--check-drift", "--config-path", str(root/".agent"/".nav-config.json")]` — read-only, no `claude plugin update`. auto_updater already implements --check-drift (auto_updater.py:531-534) returning {has_drift, plugin_version, project_version, message}. Rewrite the result-parsing branch (lines 178-192) to render a drift notice ("Update available: v{plugin} — run nav-upgrade") instead of update/failed status. Pass root into the function (currently takes only plugin_dir). The actual mutating update stays where nav-start/SKILL.md already runs it (SKILL.md:92) — the hook should only notify, not mutate. This removes the headline timeout-vs-budget hazard.
+
+3) read-counter staleness guard. In nav_read_guard.py:_increment_counter (131-145), the only reset path is session_id mismatch (line 135); the Stop reset in nav_workflow_state.py:84-108 may not fire (mem-036: Stop is silent/skippable). Add a staleness check: before incrementing, parse state["updated_at"] (already written, line 142) and if it is older than a configurable window (default ~300s via read_guard_hook.stale_after_seconds) treat the prior count as 0. Low risk — only relaxes blocking.
+
+4) nav_pre_compact path heuristic. In _compress_context (nav_pre_compact.py:125-153), replace the bare `any(ext in line for ext in (...))` substring test (line 135) with a path-shaped regex (token containing a slash plus a known extension at a word boundary), and sample head+tail of `lines` instead of only `lines[-200:]` (line 125). Mirror the same fix into skills/nav-marker/functions/marker_compressor.py (the docstring at line 111-112 says this duplicates it) to keep parity. Cosmetic-quality only — markers are advisory.
+
+5) workflow_enforcer ImportError diagnostic. In workflow_enforcer.py:51-54, add `print("workflow_enforcer: workflow_detector import failed, enforcement disabled", file=sys.stderr)` in the except branch before defining the stub. Optionally harden the sys.path.insert at line 47 to also try CLAUDE_PLUGIN_DIR (the resolution other subprocess hooks use), but the relative path is correct for the plugin layout — diagnostic is the must-have.
+
+NOTE (wp3 overlap, do NOT own here): nav_session_start.py:60 reads CLAUDE_PROJECT_ROOT while every other hook reads CLAUDE_PROJECT_DIR — Claude Code only sets CLAUDE_PROJECT_DIR, so that fallback is dead. Fix belongs to wp3-plugin-paths; coordinate the one-line change there to avoid a double edit on _project_root.
+
+### Files
+
+| File | Change |
+| --- | --- |
+| `/Users/aleks.petrov/Projects/startups/navigator/hooks/token_monitor.py` | Delete the file (retire the dead-channel, inaccurate-estimate PostToolUse hook; also resolves 0711 perms). |
+| `/Users/aleks.petrov/Projects/startups/navigator/.claude-plugin/plugin.json` | Remove the PostToolUse Edit|Write|Bash token_monitor.py block (lines 128-138); keep nav_task_graph_sync + nav_profile_sync entries. |
+| `/Users/aleks.petrov/Projects/startups/navigator/.agent/DEVELOPMENT-README.md` | Drop the token_monitor.py (legacy) row from the hook table; change 'nine hooks' to 'eight hooks'. |
+| `/Users/aleks.petrov/Projects/startups/navigator/hooks/nav_session_start.py` | Change _section_auto_update (lines 162-195) to invoke auto_updater with --check-drift --config-path (read-only) and render a drift notice; pass root in. |
+| `/Users/aleks.petrov/Projects/startups/navigator/hooks/nav_read_guard.py` | Add updated_at staleness guard in _increment_counter (treat count as 0 when older than read_guard_hook.stale_after_seconds). |
+| `/Users/aleks.petrov/Projects/startups/navigator/hooks/nav_pre_compact.py` | Replace bare extension substring match with a path-shaped regex and sample head+tail instead of only last 200 lines in _compress_context. |
+| `/Users/aleks.petrov/Projects/startups/navigator/skills/nav-marker/functions/marker_compressor.py` | Mirror the path-regex + head/tail sampling fix to keep parity with nav_pre_compact (the duplicated heuristic). |
+| `/Users/aleks.petrov/Projects/startups/navigator/hooks/workflow_enforcer.py` | Emit a one-line stderr diagnostic in the ImportError branch (lines 51-54) before defining the stub detect_workflow. |
+
+## Acceptance Criteria
+
+- [ ] grep of .claude-plugin/plugin.json contains no token_monitor reference; the file parses as valid JSON and still registers nav_task_graph_sync + nav_profile_sync on PostToolUse Edit|Write.
+- [ ] hooks/token_monitor.py no longer exists; skills/nav-upgrade migrate_hooks_out_of_settings.py still lists 'token_monitor' in its basename allowlist (existing-user cleanup preserved); its test suite stays green.
+- [ ] DEVELOPMENT-README.md hook table no longer lists token_monitor and the count reads 'eight hooks'.
+- [ ] A test feeds nav_session_start.py stdin with a Navigator project and asserts: the auto-update subprocess is invoked with --check-drift (no `claude plugin update`), and total hook wall-time stays well under the 10s budget even when the updater is slow (mock/stub claude).
+- [ ] A test for nav_read_guard.py writes a counter with updated_at older than stale_after_seconds and asserts the next increment starts from 1 (stale count treated as 0), and a fresh updated_at preserves the running count.
+- [ ] A test for nav_pre_compact._compress_context asserts a prose line like 'see the .py docs' is NOT captured as a file path while 'hooks/token_monitor.py' IS, and that paths from the transcript head are sampled (not only the tail).
+- [ ] Running workflow_enforcer.py with workflow_detector unimportable prints the 'enforcement disabled' diagnostic to stderr and still exits 0.
+- [ ] All existing hook smoke tests and wp4 hook tests pass; manual `python3 hooks/nav_session_start.py < fixture.json` returns valid JSON and does not hang.
+
+## Technical Decisions
+
+- **Recommendation**: `fix+test`. Touches the published .claude-plugin/plugin.json manifest that ships to every installed user (same surface as the v6.15.6 critical fix) — removing the token_monitor PostToolUse entry must keep the JSON valid and the remaining two PostToolUse Edit|Write entries intact. nav_session_start.py is a blocking-budget SessionStart hook: the auto-update change reduces risk (read-only vs mutating) but a parsing bug in the --check-drift branch could drop the drift notice (degraded UX, not a crash — _build_payload swallows section exceptions at line 301). The read-counter staleness guard only relaxes blocking, so worst case is a missed bulk-load warning, never a false block. No knowledge-graph data mutation. Requires Claude Code restart to re-register the changed manifest (standard for any plugin.json change).
+
+## Out of Scope
+
+- Findings outside this work-package's listed scope (see TASK-42 roadmap for the full map).
+
+## Refs
+
+- TASK-42 — Audit Remediation Roadmap (umbrella)
+- TASK-45 — dependency (`wp4-hook-tests`)
+
+## Verify
+
+```bash
+# See Acceptance Criteria; run the relevant tests/validators before marking done.
+```
+
+## Done
+
+- [ ] All acceptance criteria checked
+- [ ] Tests pass in CI (once TASK-43 gate exists)
+- [ ] Committed + roadmap (TASK-42) status updated

--- a/.agent/tasks/TASK-47-kg-integrity.md
+++ b/.agent/tasks/TASK-47-kg-integrity.md
@@ -1,0 +1,104 @@
+# TASK-47: Knowledge-graph data integrity + dormant maintenance wiring
+
+**Status**: 📋 Planned
+**Created**: 2026-06-02
+**Work-package**: `wp6-kg-integrity`
+**Phase**: 3 — Behavioral fixes (guarded)
+**Priority**: Medium
+**Effort**: L — Each code fix is small and localized, but there are ~7 distinct fixes across 4 Python files plus a data migration of a 179k JSON file plus new unit tests for code that currently has zero Python test coverage (only shell scripts in scripts/). The decay-wiring decision (track B) carries design judgment about where mutation may happen safely. Realistically 1-2 days including tests and a repeatable repair script. Splitting is reasonable (see recommendation).
+**Risk**: med — Mutates committed, git-tracked graph data (.agent/knowledge/graph.json) — a bad dedup/dangling pass could silently drop legitimate edges, so the repair must be a reviewable script with before/after counts (852->682 edges, 6 dangling removed, 1 confidence fixed) rather than hand edits. No published manifest is touched. The only blocking-hook exposure is the OPTIONAL nav_session_start.py decay wiring: that hook injects session context and must remain read-only on the hot path; writing graph.json on every session start would create noisy git churn and a per-start failure surface, so decay must be throttled and exit-0-safe or wired elsewhere. query_by_concept change is additive (new buckets) so existing callers are unaffected.
+**Depends on**: TASK-45 (wp4-hook-tests)
+**Recommendation**: `split`
+**Source**: audit `wf_0dc1b9ce-7d8` → plan `wf_187896bb-5af`; roadmap in TASK-42
+
+---
+
+## Summary
+
+Repair the corrupt graph.json data (bad confidence, duplicate + dangling edges), close the query/health/confidence code gaps that produced it, and either wire the configured decay/staleness maintenance into a real trigger or stop the config from promising it.
+
+## Findings Addressed
+
+- apply_decay does not update last_validated -> repeated runs double-decay (graph_maintenance.py:124-145)
+- Graph timestamps use naive local time labeled UTC 'Z' (graph_manager.py:32,47; graph_builder.py:394)
+- update_confidence boost math assumes fixed 0.8 base, mishandling decayed/elevated memories (graph_manager.py:407-413)
+- prune_memories leaves empty concept_index entries behind, inconsistent with remove_node (graph_maintenance.py:165-168)
+- Invalid confidence 90.0 in mem-026 renders as 9000% (graph.json + graph_manager.py:435) — confirmed: only mem-026 is out of [0,1]
+- query_by_concept silently drops marker and concept nodes despite being indexed (graph_manager.py:219-250) — confirmed: e.g. concept 'database' indexes marker 'v4.0.0-release-complete' which never appears in output
+- 170 duplicate edge rows in graph.json (852 stored vs 682 unique) — confirmed via dedup count
+- 6 dangling edge rows referencing non-existent nodes (graph.json + graph_builder.py:359-366) — confirmed: implements->'tom' (concept never normalized to canonical 'theory of mind'), learned-from->'RELEASE-v6.15.3', learned-from->'TASK-39'
+- Confidence decay and staleness pruning configured but never invoked (graph_maintenance.py:124-176; .nav-config.json knowledge_graph.confidence_decay_rate/staleness_threshold_days) — confirmed: only referenced as manual commands in nav-graph/SKILL.md, no hook/session-start caller
+- Conflict detector false-positive 'opposing guidance' via naive substring matching (graph_maintenance.py:44-65)
+- health_check has no edge-integrity coverage; reports clean score over a graph with 176 edge defects (graph_maintenance.py:179-232)
+
+**Already resolved in v6.15.6** (excluded from this work):
+- ~~The single CRITICAL audit finding (deleted nav_commit_reminder.py still registered in plugin.json) was fixed and shipped in v6.15.6 — not part of this work-package and confirmed unrelated to any nav-graph finding here. plugin.json version reads 6.15.6.~~
+
+## Implementation
+
+Two coherent tracks: (A) data repair + code guards, (B) decay/staleness wiring.
+
+(A1) Data fix in .agent/knowledge/graph.json: set mem-026 confidence 90.0 -> 0.9; dedup the edges array to the 682 unique (from,to,type) rows; drop the 6 dangling edges (implements->'tom', learned-from->'RELEASE-v6.15.3', learned-from->'TASK-39'). Do this with a one-shot repair script (committed under scripts/ or run via graph_maintenance --action repair) rather than hand-editing 179k of JSON.
+
+(A2) graph_builder.infer_edges (line 360-366): normalize each task concept through the same map build_concept_nodes uses before emitting the 'implements' edge — the concept node store uses canonical 'theory of mind' but infer_edges emits raw 'tom'. Simplest fix: emit edges to the canonical concept (the concepts already come from extract_concepts_from_text which normalizes, but raw legacy 'tom' slipped in) and add a referential-integrity filter that drops any edge whose from/to is not a known node id before returning the graph. Route build_graph's edge list through add_edge (graph_manager.py:127, already has dedup at 138-143) instead of the raw infer_edges append so dedup is enforced at build time, killing the 170-dup root cause.
+
+(A3) graph_manager.query_by_concept (line 219-250): add 'markers' and 'concepts' to type_to_category, add matching buckets to the results dict (228-236), and add render sections in format_query_results (450-487) with _format_marker/_format_concept helpers. Markers are genuinely indexed (verified) so this surfaces real data.
+
+(A4) graph_manager.add_memory (322) and update_confidence (393): clamp/validate confidence to [0,1] on input (reject or normalize >1.0); fix the boost math at 407-413 — drop the hardcoded `current_boost = confidence - 0.8` anchor and instead clamp boost at min(confidence+0.05, 1.0) or track an original_confidence field, so decayed/elevated memories boost correctly. Fix the 'Z' timestamp bug at graph_manager.py:32,47 and graph_builder.py:394 using datetime.now(timezone.utc).isoformat().
+
+(A5) graph_maintenance.health_check (179-232): add duplicate-edge count, dangling-edge count (from/to not in union of node ids — note concepts node-keys must be included), and confidence-range validation (flag any memory outside [0,1]); factor each into health_score and the issues list. Fix prune_memories (165-168) to delete now-empty concept_index keys mirroring remove_node (114-116), or route through remove_node.
+
+(B) Decay/staleness wiring: apply_decay (124-145) currently re-decays every run because it never records when it last ran. Fix idempotency first: read knowledge_graph.confidence_decay_rate from .nav-config.json, decay against a persisted per-memory last_decayed (or graph-level last_decayed date) so a given calendar day decays at most once. Then add a 'maintenance' action that runs decay+stale read-only-safe and gate it behind a once-per-day throttle. Wire it via the existing nav_task_graph_sync.py pattern OR a small addition to nav_session_start.py — but session-start MUST stay read-only for context injection; if decay mutates graph.json on every start it fights git_tracked:true. Recommended: throttled (>=24h since last_decayed) decay invoked from a PostCompact path or an explicit nav-graph maintenance command, NOT on every session start. If wiring is deemed too risky for this pass, the fallback is to mark decay/staleness experimental in SKILL.md and the config keys, and update the stale SKILL.md health-output example (shows 'Memories: 2', real graph has 37).
+
+(C) Conflict detector (44-65): downgrade to advisory — keep detection but stop letting it subtract from health_score, and add a SKILL.md note that it is heuristic / high-false-positive. Word-boundary matching is a nice-to-have, not required this pass.
+
+### Files
+
+| File | Change |
+| --- | --- |
+| `.agent/knowledge/graph.json` | mem-026 confidence 90.0->0.9; dedup 852->682 edges; drop 6 dangling edges (implements->tom, learned-from->RELEASE-v6.15.3, learned-from->TASK-39) |
+| `skills/nav-graph/functions/graph_builder.py` | infer_edges: normalize concept before 'implements' edge + referential-integrity filter; route build_graph edges through add_edge for dedup; fix 'Z' timestamp at line 394 |
+| `skills/nav-graph/functions/graph_manager.py` | query_by_concept + format_query_results: add markers/concepts buckets & render; add_memory/update_confidence: clamp confidence to [0,1] and fix 0.8-anchored boost; fix naive-UTC 'Z' at lines 32,47 |
+| `skills/nav-graph/functions/graph_maintenance.py` | apply_decay: idempotent via persisted last_decayed + config rate; prune_memories: delete empty concept_index keys; health_check: add duplicate-edge/dangling-edge/confidence-range checks into score+issues; conflicts advisory (no score penalty) |
+| `skills/nav-graph/SKILL.md` | refresh stale health-output example (2->37 memories); document conflict detection as heuristic; document decay/staleness trigger (or mark experimental) |
+| `.agent/.nav-config.json` | only if decay is NOT wired: annotate/remove confidence_decay_rate & staleness_threshold_days so config does not promise unrun behavior |
+| `hooks/nav_session_start.py` | OPTIONAL, only if throttled decay is wired here: add >=24h-throttled decay call kept strictly side-effect-safe; do not mutate graph on every start |
+
+## Acceptance Criteria
+
+- [ ] After repair, `graph_maintenance.py --action health` reports 0 duplicate edges, 0 dangling edges, and 0 memories with confidence outside [0,1]; health_score reflects these as zero defects
+- [ ] `python3 -c` dedup check on graph.json returns 682 stored == 682 unique edges (currently 852 stored / 682 unique)
+- [ ] No edge in graph.json references a from/to id absent from the union of all node-type keys (currently 6 dangling: tom, RELEASE-v6.15.3, TASK-39)
+- [ ] mem-026 confidence == 0.9 and _format_memory renders it as 90% (not 9000%)
+- [ ] Querying a concept that indexes a marker (e.g. 'database' -> 'v4.0.0-release-complete') now lists that marker in query output instead of dropping it
+- [ ] Running `--action decay` twice on the same calendar day produces identical confidence values (idempotent); decay reads confidence_decay_rate from .nav-config.json
+- [ ] After prune_memories with --execute, no concept_index key maps to an empty list
+- [ ] add_memory/update_confidence reject or normalize a confidence > 1.0
+- [ ] All new behavior covered by Python unit tests under a tests/ path (build dedup, dangling filter, query markers bucket, decay idempotency, health-check defect counts, confidence clamp) — first Python tests for nav-graph
+- [ ] If decay is not wired to a trigger, .nav-config.json + SKILL.md no longer present decay/staleness as active automatic behavior; if wired, nav_session_start.py stays read-only on its context-injection path and decay is throttled to <=1/day
+
+## Technical Decisions
+
+- **Recommendation**: `split`. Mutates committed, git-tracked graph data (.agent/knowledge/graph.json) — a bad dedup/dangling pass could silently drop legitimate edges, so the repair must be a reviewable script with before/after counts (852->682 edges, 6 dangling removed, 1 confidence fixed) rather than hand edits. No published manifest is touched. The only blocking-hook exposure is the OPTIONAL nav_session_start.py decay wiring: that hook injects session context and must remain read-only on the hot path; writing graph.json on every session start would create noisy git churn and a per-start failure surface, so decay must be throttled and exit-0-safe or wired elsewhere. query_by_concept change is additive (new buckets) so existing callers are unaffected.
+- **Split**: Track A = data repair (dedup, mem-026 0.90, dangling edges) is low-risk and ships first. Track B = decay/staleness wiring mutates on session start; defer or mark experimental in config + SKILL.md if risk judged too high this pass.
+
+## Out of Scope
+
+- Findings outside this work-package's listed scope (see TASK-42 roadmap for the full map).
+
+## Refs
+
+- TASK-42 — Audit Remediation Roadmap (umbrella)
+- TASK-45 — dependency (`wp4-hook-tests`)
+
+## Verify
+
+```bash
+# See Acceptance Criteria; run the relevant tests/validators before marking done.
+```
+
+## Done
+
+- [ ] All acceptance criteria checked
+- [ ] Tests pass in CI (once TASK-43 gate exists)
+- [ ] Committed + roadmap (TASK-42) status updated

--- a/.agent/tasks/TASK-48-detection-precision.md
+++ b/.agent/tasks/TASK-48-detection-precision.md
@@ -1,0 +1,84 @@
+# TASK-48: Detection precision: token-boundary matching + consolidate complexity impls
+
+**Status**: 📋 Planned
+**Created**: 2026-06-02
+**Work-package**: `wp7-detection`
+**Phase**: 3 — Behavioral fixes (guarded)
+**Priority**: Medium
+**Effort**: M — ~half-day. The three edits are small and mechanical (regex swap, char-class fix, file delete). Bulk of the time is writing the new workflow_detector test suite from scratch (currently untested, and it gates a blocking hook) plus re-running test_complexity_detector.py (33 tests) and the enforcer smoke path to confirm the contract and exit-code behavior are unchanged. Not S because workflow_detector feeds a user-facing blocking hook and deserves real test coverage before/after.
+**Risk**: med — workflow_detector.detect_workflow is imported by the exit(2) blocking enforcer hook (hooks/workflow_enforcer.py:50) registered in the published plugin.json manifest. Removing 'everything' REDUCES false blocks (the safe direction), but tightening complexity word boundaries could lower some borderline scores below the 0.5 task_mode threshold — verify representative prompts still classify correctly. Must preserve the exact dict keys detect_workflow returns or the hook's fallback stub diverges. Deleting complexity_scorer.py is low-risk (no importers). No knowledge-graph mutation involved. Manifest itself is not edited.
+**Depends on**: TASK-45 (wp4-hook-tests)
+**Recommendation**: `fix+test`
+**Source**: audit `wf_0dc1b9ce-7d8` → plan `wf_187896bb-5af`; roadmap in TASK-42
+
+---
+
+## Summary
+
+Eliminate substring/loop-trigger false positives that route innocuous prompts into LOOP/TASK mode (and the exit(2) enforcer block), and consolidate three divergent complexity scorers onto the single tested implementation.
+
+## Findings Addressed
+
+- complexity_scorer.py substring matching inflates complexity (skills/nav-start/functions/complexity_scorer.py:114-117)
+- workflow_detector.py bare 'everything' loop trigger + substring matching fires on innocuous mentions and feeds the exit(2) blocking enforcer (skills/nav-start/functions/workflow_detector.py:32-49,109-111)
+- analyze_unclear_names regex [a-hln-z] wrongly excludes 'm' in addition to i/j/k (skills/nav-simplify/scripts/code_analyzer.py:191-192)
+- three divergent complexity implementations with no shared logic (complexity_scorer.calculate_score, workflow_detector.calculate_complexity, complexity_detector.detect_complexity)
+
+**Already resolved in v6.15.6** (excluded from this work):
+- ~~v6.15.6 removed the dead nav_commit_reminder.py PostToolUse(Bash) hook from plugin.json and synced DEVELOPMENT-README to nine hooks — unrelated to detection precision; none of this WP's four findings were touched by it~~
+
+## Implementation
+
+Verified ground truth before scoping: (1) complexity_scorer.py has ZERO importers anywhere (grep `from complexity_scorer`/`import complexity_scorer` = empty; only its own docstring at lines 9-11 references it) and no test file — it is dead code. (2) The only live path through a BLOCKING hook is hooks/workflow_enforcer.py line 50 `from workflow_detector import detect_workflow`, registered as UserPromptSubmit in .claude-plugin/plugin.json line 110. (3) complexity_detector.py (nav-workflow) already uses `re.search(r'\b...\b')` word boundaries throughout and has 33 passing tests in test_complexity_detector.py exercising detect_signals/calculate_complexity/detect_complexity. (4) Reproduced the false positive live: `detect_workflow("Please document everything we discussed")` returns loop_mode=True, trigger='everything', mode=LOOP — which feeds workflow_enforcer's exit(2) branch. (5) Confirmed `[a-hln-z]` excludes i,j,k AND m (a-h, l, n-z skips m) via direct regex test.
+
+Work, smallest-blast-radius first:
+- code_analyzer.py:192 — replace single_letter_pattern char class with capture-any-single-letter `\b(const|let|var)\s+([a-z])\s*=` and add an explicit skip set `{"i","j","k"}` in the analyze_unclear_names loop (lines 194-203) so 'm' (and any non-loop single letter) is flagged again. Mirrors the audit rec. test_roi_scoring.py only uses synthetic `{"type":"unclear_naming"}` dicts (lines 30,32,138), so no existing test breaks; add a focused unit test.
+- workflow_detector.py — (a) LOOP_TRIGGERS (lines 32-49): drop bare "everything" and "all of it"; keep multi-word phrases ("complete everything", "do all", "run until done", etc.). (b) detect_loop_trigger (lines 109-111): match each phrase on token boundaries — compile `re.compile(r'\b' + re.escape(phrase) + r'\b')` (handles internal apostrophes/spaces fine) instead of `phrase in message_lower`. (c) calculate_complexity (lines 128-149): replace `indicator in message_lower` substring checks with `re.search(r'\b'+re.escape(indicator)+r'\b', message_lower)` so "add" no longer matches "address", "modify" no longer matches "modifying" mid-word, etc. Preserve the exact return contract `(score, matched)` and the dict shape detect_workflow returns (loop_mode, loop_trigger, task_mode, complexity, recommended_mode) — the enforcer hook and its fallback depend on it.
+- Consolidation: delete complexity_scorer.py (dead, no importers, no tests) rather than fix it — removes one of the three divergent impls outright. Do NOT attempt to merge workflow_detector.calculate_complexity into complexity_detector.detect_complexity in this WP: they have incompatible scoring contracts (additive-from-0 with per-indicator weights vs base-0.5 ± signed adjustments) and the enforcer's loop-trigger detection has no analog in complexity_detector. Consolidating leaves two impls (the tested complexity_detector for nav-workflow's skill-deferral path, and the boundary-hardened workflow_detector for the enforcer hook); document in the task doc why a full single-impl merge is deferred (would change enforcer block thresholds — needs its own risk-managed WP).
+- Add a test file skills/nav-start/functions/test_workflow_detector.py (currently NONE) asserting: bare "everything"/"all of it" no longer trigger LOOP; legitimate phrases still trigger; substring non-matches ("address" ≠ "add", "modifying" ≠ "modify") score lower; detect_workflow contract keys preserved.
+
+### Files
+
+| File | Change |
+| --- | --- |
+| `skills/nav-start/functions/workflow_detector.py` | Remove bare 'everything'/'all of it' from LOOP_TRIGGERS; switch detect_loop_trigger and calculate_complexity to compiled \b...\b word-boundary regex; preserve return contract |
+| `skills/nav-start/functions/complexity_scorer.py` | Delete — dead code (zero importers, no tests); removes one of three divergent complexity impls |
+| `skills/nav-simplify/scripts/code_analyzer.py` | Fix analyze_unclear_names regex to [a-z] and skip {i,j,k} programmatically so 'm' is flagged again (line 192 + loop 194-203) |
+| `skills/nav-start/functions/test_workflow_detector.py` | New test file: assert no false-positive loop triggers, word-boundary complexity matching, and preserved detect_workflow output keys |
+| `skills/nav-simplify/scripts/test_roi_scoring.py` | Add a unit test for analyze_unclear_names asserting 'm' flagged and i/j/k skipped (verify path; existing synthetic-dict tests unaffected) |
+
+## Acceptance Criteria
+
+- [ ] detect_workflow('Please document everything we discussed') returns loop_mode=False, recommended_mode != 'LOOP'
+- [ ] detect_workflow('run until done: fix the bug') still returns loop_mode=True with trigger 'run until done'
+- [ ] calculate_complexity('fix the address field') does not match 'add' (no 'low:add' in matched); calculate_complexity('add a feature') does match 'add'
+- [ ] complexity_scorer.py is deleted and `grep -rn complexity_scorer` returns no live references
+- [ ] analyze_unclear_names flags 'const m = 1' and does NOT flag const i/j/k; existing test_roi_scoring.py 20 tests still pass
+- [ ] new skills/nav-start/functions/test_workflow_detector.py passes and covers loop-trigger boundaries + complexity word boundaries + detect_workflow contract keys
+- [ ] skills/nav-workflow/functions/test_complexity_detector.py 33 tests still pass unchanged
+- [ ] workflow_enforcer.py end-to-end smoke: innocuous 'everything' prompt exits 0 (no block)
+
+## Technical Decisions
+
+- **Recommendation**: `fix+test`. workflow_detector.detect_workflow is imported by the exit(2) blocking enforcer hook (hooks/workflow_enforcer.py:50) registered in the published plugin.json manifest. Removing 'everything' REDUCES false blocks (the safe direction), but tightening complexity word boundaries could lower some borderline scores below the 0.5 task_mode threshold — verify representative prompts still classify correctly. Must preserve the exact dict keys detect_workflow returns or the hook's fallback stub diverges. Deleting complexity_scorer.py is low-risk (no importers). No knowledge-graph mutation involved. Manifest itself is not edited.
+
+## Out of Scope
+
+- Merging `workflow_detector.calculate_complexity` into the tested `complexity_detector` (changes enforcer block thresholds — separate risk-managed WP).
+
+## Refs
+
+- TASK-42 — Audit Remediation Roadmap (umbrella)
+- TASK-45 — dependency (`wp4-hook-tests`)
+
+## Verify
+
+```bash
+# See Acceptance Criteria; run the relevant tests/validators before marking done.
+```
+
+## Done
+
+- [ ] All acceptance criteria checked
+- [ ] Tests pass in CI (once TASK-43 gate exists)
+- [ ] Committed + roadmap (TASK-42) status updated

--- a/.agent/tasks/TASK-49-plugin-paths.md
+++ b/.agent/tasks/TASK-49-plugin-paths.md
@@ -1,0 +1,95 @@
+# TASK-49: Plugin-relative path resolution (skills + hooks work outside the source repo)
+
+**Status**: 📋 Planned
+**Created**: 2026-06-02
+**Work-package**: `wp3-plugin-paths`
+**Phase**: 4 — Independent tracks (parallel)
+**Priority**: Medium
+**Effort**: L — ~16 files. The two hook edits are S each (one is a one-token change; workflow_enforcer needs a ~15-line stdin-refactor since get_user_message reads stdin destructively). The skill edits are mechanical but voluminous: 41 bare `python3 skills/` lines across 12 files plus 4 bare `scripts/` files, each needing a resolver block prepended per code block. Audit under-counted ("9 skills"); actual is 12+4. Verification (running helpers from a non-repo cwd with the backstop bypassed) is the real time sink, pushing this to a low-end L rather than M.
+**Risk**: med — workflow_enforcer.py is the only BLOCKING hook (UserPromptSubmit exit 2); its stdin-read refactor must preserve the never-block-on-missing-state invariant. SKILL.md edits ship in the published plugin manifest. No graph-data mutation risk (only executable paths change, not data args). The $HOME/.claude/plugins fallback chain must be verified since CLAUDE_PLUGIN_DIR availability in skill Bash is uncertain.
+**Depends on**: none
+**Recommendation**: `fix+test`
+**Source**: audit `wf_0dc1b9ce-7d8` → plan `wf_187896bb-5af`; roadmap in TASK-42
+
+---
+
+## Summary
+
+Make every Navigator skill helper invocation and hook config/state read resolve from the installed plugin/project location so knowledge-graph, stats, version-check, and workflow-enforcement features stop silently no-opping in real (non-source-repo) installs.
+
+## Findings Addressed
+
+- medium: nav_session_start.py:60 reads CLAUDE_PROJECT_ROOT while all 7 other hooks read CLAUDE_PROJECT_DIR
+- low: workflow_enforcer.py:96,112 use cwd-relative paths for config and state, disagreeing with the absolute path written by nav_workflow_state.py:217
+- medium: knowledge-graph helper paths are bare 'python3 skills/nav-graph/functions/...' in 12 SKILL.md files (41 invocation lines) and fail outside the source repo
+- medium: nav-stats and nav-start invoke 'scripts/...' via bare cwd-relative paths (session-stats, check-version dead outside source repo); nav-install-multi-claude has the same bare 'scripts/install-multi-claude.sh' pattern
+
+**Already resolved in v6.15.6** (excluded from this work):
+- ~~CRITICAL deleted nav_commit_reminder.py hook still registered in plugin.json — removed in v6.15.6 (not part of this WP)~~
+
+## Implementation
+
+Three independent sub-fixes, all grounding on the resolution pattern already proven in nav-upgrade/SKILL.md:340-342 (`PLUGIN_DIR="${CLAUDE_PLUGIN_DIR:-$HOME/.claude/plugins/cache/navigator-marketplace/navigator}"` with a `$HOME/.claude/plugins/marketplaces/navigator-marketplace` second fallback) and the hook helper `_resolve_plugin_dir()` in nav_session_start.py:234-250.
+
+(1) Hook env-var consistency (S): In hooks/nav_session_start.py:60 change `CLAUDE_PROJECT_ROOT` to `CLAUDE_PROJECT_DIR` to match the identical `_project_root` helpers in the 7 other hooks (nav_read_guard.py:78, nav_workflow_state.py:74, nav_profile_sync.py:52, nav_post_compact.py:47, nav_task_graph_sync.py:56, nav_pre_compact.py:56). Latent-only today because stdin `cwd` is preferred first, but it is the documented variable and the only env fallback.
+
+(2) workflow_enforcer path agreement (S/M): hooks/workflow_enforcer.py:96 (`Path(".agent/.nav-config.json")`) and :112 (`Path(".agent/.nav-workflow-state.json")`) are cwd-relative, but the writer nav_workflow_state.py:217 writes `root/.agent/.nav-workflow-state.json` (absolute, derived from stdin cwd). Add a `_project_root(stdin_data)` helper mirroring the other hooks, then build both `config_path` and `state_path` under that root. Complication: `get_user_message()` (line 72) destructively does `sys.stdin.read()` and only extracts `prompt`. Refactor it to parse the stdin JSON once into a dict, return both the message and the parsed payload (or stash it), so `cwd` survives for root derivation. Keep the empty-dict-on-missing-state behavior (the "no signal, never block" contract at line 108-119) intact.
+
+(3) Skill helper path resolution (M): In the 12 SKILL.md files with bare `python3 skills/nav-graph/functions/...` and the 4 with bare `scripts/...`, prepend a one-line resolver and rewrite invocations to `"$PLUGIN_DIR/skills/nav-graph/functions/X.py"` / `"$PLUGIN_DIR/scripts/X.sh"`. DO NOT use `$SKILL_BASE_DIR` as the audit rec suggests — the repo's own mem-018 / graph.json:1505 records that `$SKILL_BASE_DIR` is NOT a Claude Code built-in and is unset, which is exactly why v6.4.0 reverted nav-simplify away from it. Standardize on `${CLAUDE_PLUGIN_DIR:-...cache.../navigator}` with the marketplace fallback. The data-path args (`--graph-path .agent/knowledge/graph.json`, `--agent-dir .agent`) stay project-relative — only the helper executable path changes. While here, fix the inconsistent existing nav-start fallbacks (SKILL.md:90/217/354/548 point at `.../marketplaces/.../skills/nav-start` but :249 points at `.../cache/.../navigator`) to the single canonical form.
+
+All three are doc/script-string edits plus one ~15-line Python helper; no helper .py logic changes. The source repo's `.claude/settings.json` backstop (present, per ls) is what has been masking these in dev — same masking that hid the v6.14.0 bug for two releases (nav-release/SKILL.md:83), so verification must explicitly run with CLAUDE_PLUGIN_DIR unset / from a temp non-repo cwd.
+
+### Files
+
+| File | Change |
+| --- | --- |
+| `hooks/nav_session_start.py` | Line 60: CLAUDE_PROJECT_ROOT -> CLAUDE_PROJECT_DIR for parity with the 7 other hooks. |
+| `hooks/workflow_enforcer.py` | Add _project_root(stdin_data) helper; refactor get_user_message to retain parsed stdin (cwd); build config_path (line 96) and state_path (line 112) under that absolute root. |
+| `skills/nav-graph/SKILL.md` | 17 invocation lines: prepend ${CLAUDE_PLUGIN_DIR}-based PLUGIN_DIR resolver; rewrite python skills/nav-graph/functions/*.py -> "$PLUGIN_DIR/skills/nav-graph/functions/*.py". |
+| `skills/backend-endpoint/SKILL.md` | Lines 37,358: nav-graph helper paths -> $PLUGIN_DIR-resolved. |
+| `skills/backend-test/SKILL.md` | Lines 30,147: nav-graph helper paths -> $PLUGIN_DIR-resolved. |
+| `skills/frontend-component/SKILL.md` | Lines 37,353: nav-graph helper paths -> $PLUGIN_DIR-resolved. |
+| `skills/frontend-test/SKILL.md` | Lines 28,32,144: nav-graph helper paths -> $PLUGIN_DIR-resolved. |
+| `skills/database-migration/SKILL.md` | Lines 43,356: nav-graph helper paths -> $PLUGIN_DIR-resolved. |
+| `skills/nav-profile/SKILL.md` | Line 249: correction_to_memory.py path -> $PLUGIN_DIR-resolved. |
+| `skills/nav-marker/SKILL.md` | Line 198: graph_manager.py stats path -> $PLUGIN_DIR-resolved. |
+| `skills/nav-task/SKILL.md` | Line 370: task_to_graph.py path -> $PLUGIN_DIR-resolved. |
+| `skills/nav-simplify/SKILL.md` | 1 bare skills/ invocation -> $PLUGIN_DIR-resolved (note mem-018: do NOT reintroduce $SKILL_BASE_DIR). |
+| `skills/nav-onboard/SKILL.md` | 6 bare skills/ invocation lines -> $PLUGIN_DIR-resolved. |
+| `skills/nav-stats/SKILL.md` | Lines 46,53,72 (scripts/session-stats.sh) and line 75 (efficiency_scorer.py) -> $PLUGIN_DIR-resolved. |
+| `skills/nav-start/SKILL.md` | Lines 68-69 (scripts/check-version.sh) -> $PLUGIN_DIR-resolved; unify the 5 existing SKILL_BASE_DIR fallbacks (90/217/249/354/548) to the single canonical CLAUDE_PLUGIN_DIR form. |
+| `skills/nav-install-multi-claude/SKILL.md` | Line 150 (scripts/install-multi-claude.sh) -> $PLUGIN_DIR-resolved. |
+
+## Acceptance Criteria
+
+- [ ] grep for `python3 skills/` / `python skills/` across skills/*/SKILL.md returns zero bare (non-$PLUGIN_DIR/$CLAUDE_PLUGIN_DIR-prefixed) matches.
+- [ ] grep for `bash scripts/` / `-f "scripts/` across skills/*/SKILL.md returns zero bare matches.
+- [ ] No SKILL.md introduces or retains `$SKILL_BASE_DIR` as a helper-path base (consistent with mem-018 / v6.4.0 revert).
+- [ ] hooks/nav_session_start.py uses CLAUDE_PROJECT_DIR; grep for CLAUDE_PROJECT_ROOT in hooks/ returns nothing.
+- [ ] workflow_enforcer.py resolves config_path and state_path under the same absolute root that nav_workflow_state.py writes to; a unit/integration test pipes stdin {prompt, cwd:<tmpdir>} with a state file under <tmpdir>/.agent and asserts the enforcer reads it (and still returns no-block when the file is absent).
+- [ ] Manual/scripted run: from a temp cwd that is NOT the source repo and with CLAUDE_PLUGIN_DIR unset, invoke a nav-graph helper line and scripts/session-stats.sh as rewritten and confirm they resolve and execute (current behavior: silent no-op).
+- [ ] Existing hook tests (wp4) still pass; workflow_enforcer block/no-block behavior unchanged for the cwd==root case.
+
+## Technical Decisions
+
+- **Recommendation**: `fix+test`. workflow_enforcer.py is the only BLOCKING hook (UserPromptSubmit exit 2); its stdin-read refactor must preserve the never-block-on-missing-state invariant. SKILL.md edits ship in the published plugin manifest. No graph-data mutation risk (only executable paths change, not data args). The $HOME/.claude/plugins fallback chain must be verified since CLAUDE_PLUGIN_DIR availability in skill Bash is uncertain.
+
+## Out of Scope
+
+- Findings outside this work-package's listed scope (see TASK-42 roadmap for the full map).
+
+## Refs
+
+- TASK-42 — Audit Remediation Roadmap (umbrella)
+
+## Verify
+
+```bash
+# See Acceptance Criteria; run the relevant tests/validators before marking done.
+```
+
+## Done
+
+- [ ] All acceptance criteria checked
+- [ ] Tests pass in CI (once TASK-43 gate exists)
+- [ ] Committed + roadmap (TASK-42) status updated

--- a/.agent/tasks/TASK-50-skill-templates.md
+++ b/.agent/tasks/TASK-50-skill-templates.md
@@ -1,0 +1,93 @@
+# TASK-50: Skill template/reference integrity
+
+**Status**: 📋 Planned
+**Created**: 2026-06-02
+**Work-package**: `wp8-skill-templates`
+**Phase**: 1 — Gate + zero-dep quick wins
+**Priority**: High
+**Effort**: M — Mostly markdown surgery in two ~640-line SKILL.md files plus a one-line nav-stats edit and six empty-dir removals. No code logic changes. Bulk of the time is careful section deletion/renumbering and re-reading the edited SKILL.md to confirm no dangling cross-references remain. The version-convention decision adds a small docs touch. Comfortably under a half-day; not S because there are two large files with interdependent step/function/template/example lists that must stay self-consistent.
+**Risk**: low — No blocking hook, no published JSON manifest, no knowledge-graph mutation. Changes are doc-only (SKILL.md text, frontmatter version strings) plus deletion of confirmed-empty directories. Worst case is over-trimming a step that the model could otherwise have run; mitigated by keeping the inline-fallback phrasing. The only published surface is skill frontmatter (loaded by Claude Code at session start) — version bumps are cosmetic and safe. Removing empty dirs cannot break the test skills since their SKILL.md never references those paths.
+**Depends on**: none
+**Recommendation**: `fix-now`
+**Source**: audit `wf_0dc1b9ce-7d8` → plan `wf_187896bb-5af`; roadmap in TASK-42
+
+---
+
+## Summary
+
+Make backend-endpoint and frontend-component SKILL.md reference only files that actually ship, fix the express-route placeholder list, normalize stale skill versions, and remove the false "v3.5.0+" string and empty test-skill scaffolding so the model never invokes nonexistent generators/templates.
+
+## Findings Addressed
+
+- backend-endpoint references missing functions/templates/examples (error_handler_generator.py, test_generator.py, error-handler/fastify/graphql-resolver/validation-zod templates, graphql-resolver.ts example)
+- frontend-component references missing component-with-hooks-template.tsx, component-container-template.tsx, and UserProfile.tsx example
+- express-route-template.ts documented placeholders do not match actual template placeholders
+- stale/inconsistent skill frontmatter versions (backend-endpoint/frontend-component at 1.0.0 despite Next.js + graph additions; mixed 1.0.0/2.0.0/1.1.0 across skills)
+- nav-stats hard-codes 'requires Navigator v3.5.0+' string in a v6.15.6 plugin (own the string only; the false-trigger path fix belongs to wp3)
+- backend-test and frontend-test ship empty examples/functions/templates directories
+
+**Already resolved in v6.15.6** (excluded from this work):
+- ~~None of these findings were resolved by v6.15.6 — commit e5aff9f only removed the deleted nav_commit_reminder.py block from plugin.json/DEVELOPMENT-README and synced versions; it did not touch any skills/* file in this work-package (verified via git log on skills/backend-endpoint, frontend-component, backend-test, frontend-test, nav-stats/SKILL.md).~~
+
+## Implementation
+
+Documentation-trimming over file-creation, matching the maintainers' prior approach in commit 1d63f86 ("repair generators" by editing existing files, not expanding the matrix).
+
+backend-endpoint/SKILL.md: (1) Delete Step 4 "Generate Error Handling Middleware" (lines 215-224) and Step 5 "Generate Test File" (lines 233-244) OR rewrite them to "the model writes this inline" — both `functions/error_handler_generator.py` and `functions/test_generator.py` are confirmed absent on disk. Renumber Steps 6-8 accordingly (or keep numbering, just drop the bash invocations of missing scripts). (2) Remove function entries #4 (error_handler_generator.py, lines 441-452) and #5 (test_generator.py, lines 456-476) from the Predefined Functions section; only route_validator.py, endpoint_generator.py, validation_generator.py ship. (3) In the Templates section, delete the `fastify-route-template.ts` (520-522), `graphql-resolver-template.ts` (524-526), and `validation-zod-template.ts` (528-530) blocks — none exist; note Zod is generated inline by validation_generator.py (which builds the schema via ZOD_TYPE_MAP, no template). Keep express + the two nextjs template blocks (those files exist). The endpoint-test-template.spec.ts file DOES exist so its block (532-539) can stay, but since no generator drives it, reframe it as "reference test shape." (4) In Examples (lines 547-549) remove the `graphql-resolver.ts` bullet — only users-get.ts and users-post.ts exist. (5) Fix express-route-template placeholder list (486-491): the actual template uses ${ROUTE_PATH}, ${HTTP_METHOD}, ${RESOURCE_NAME}, ${RESOURCE_NAME_LOWER}, ${HTTP_METHOD_LOWER}, ${MIDDLEWARE_BLOCK}; replace the listed ${VALIDATION_MIDDLEWARE}/${AUTH_MIDDLEWARE} (the express template does not use them — it uses ${MIDDLEWARE_BLOCK} which endpoint_generator.py builds from auth+validation flags) with the three missing ones. (Note: ${VALIDATION_MIDDLEWARE}/${AUTH_MIDDLEWARE} DO exist in endpoint_generator.py's substitution dict, lines 68-69, but are not present in the express template — so the doc should list what the template actually contains.)
+
+frontend-component/SKILL.md: (1) In Step 3 (lines 164-172) remove the "Component with hooks" and "Container component" template references — `component-with-hooks-template.tsx` and `component-container-template.tsx` are absent; only component-simple-template.tsx + the four nextjs-* templates exist. Either drop with-hooks/container from the Step 1 type menu (lines 61-63) too, or keep them as "uses simple template + model fills hooks." (2) Remove the Templates blocks for component-with-hooks-template.tsx (488-494) and component-container-template.tsx (496-503). (3) Examples (line 530): remove the `UserProfile.tsx - Container component` bullet — only Button.tsx and SearchBar.tsx exist on disk.
+
+Version normalization: bump backend-endpoint and frontend-component frontmatter `version:` from 1.0.0 (they have Next.js + knowledge-graph additions, so should be >= 2.0.0 to match backend-test/frontend-test/database-migration which are already 2.0.0). Decide a single convention — recommend per-skill semver bumped on material SKILL.md change; document it once in DEVELOPMENT-README or a CONTRIBUTING note. Do not attempt to retro-version all 29 skills; just correct the two that are demonstrably understated.
+
+nav-stats/SKILL.md:48 — change the string "This feature requires Navigator v3.5.0+" to a version-neutral message (e.g. "Session stats script missing — reinstall Navigator"). The actual false-trigger is the cwd-relative `scripts/session-stats.sh` check (line 46); scripts/session-stats.sh exists, so the branch only fires on a path-resolution miss. That path fix is wp3's nav-stats cwd-path item — own only the string here.
+
+backend-test / frontend-test: `git rm` the empty examples/, functions/, templates/ directories (confirmed empty; SKILL.md v2.0.0 never references files in them and explicitly relies on inline templates + the model). Alternatively add a .gitkeep with a one-line README explaining they are intentionally model-driven, but removal is cleaner and matches the SKILL.md "When NOT to Use" framing.
+
+### Files
+
+| File | Change |
+| --- | --- |
+| `/Users/aleks.petrov/Projects/startups/navigator/skills/backend-endpoint/SKILL.md` | Remove Steps 4-5 + function entries #4-#5 (missing error_handler_generator.py/test_generator.py); drop fastify/graphql-resolver/validation-zod template blocks and graphql-resolver.ts example; fix express-route placeholder list to ${RESOURCE_NAME_LOWER}/${HTTP_METHOD_LOWER}/${MIDDLEWARE_BLOCK}; bump version to 2.0.0 |
+| `/Users/aleks.petrov/Projects/startups/navigator/skills/frontend-component/SKILL.md` | Remove with-hooks/container template references (Step 3 + Templates section) and UserProfile.tsx example; reconcile Step 1 type menu; bump version to 2.0.0 |
+| `/Users/aleks.petrov/Projects/startups/navigator/skills/nav-stats/SKILL.md` | Line 48: replace stale 'requires Navigator v3.5.0+' string with version-neutral message |
+| `/Users/aleks.petrov/Projects/startups/navigator/skills/backend-test/examples` | Remove empty directory (git rm) — unused, SKILL.md is model-driven |
+| `/Users/aleks.petrov/Projects/startups/navigator/skills/backend-test/functions` | Remove empty directory (git rm) |
+| `/Users/aleks.petrov/Projects/startups/navigator/skills/backend-test/templates` | Remove empty directory (git rm) |
+| `/Users/aleks.petrov/Projects/startups/navigator/skills/frontend-test/examples` | Remove empty directory (git rm) |
+| `/Users/aleks.petrov/Projects/startups/navigator/skills/frontend-test/functions` | Remove empty directory (git rm) |
+| `/Users/aleks.petrov/Projects/startups/navigator/skills/frontend-test/templates` | Remove empty directory (git rm) |
+| `/Users/aleks.petrov/Projects/startups/navigator/skills/frontend-component/functions/__pycache__/test_generator.cpython-314.pyc` | Remove stray committed pyc (cleanup, optional) and add functions/__pycache__ to .gitignore if not already ignored |
+
+## Acceptance Criteria
+
+- [ ] Every functions/templates/examples path referenced in backend-endpoint/SKILL.md and frontend-component/SKILL.md resolves to a file that exists on disk (verify with a script that greps `functions/`, `templates/`, `examples/` references and stats each).
+- [ ] express-route-template.ts placeholder list in SKILL.md (around line 486) lists exactly the placeholders present in templates/express-route-template.ts: ${ROUTE_PATH}, ${HTTP_METHOD}, ${RESOURCE_NAME}, ${RESOURCE_NAME_LOWER}, ${HTTP_METHOD_LOWER}, ${MIDDLEWARE_BLOCK}; no ${VALIDATION_MIDDLEWARE}/${AUTH_MIDDLEWARE} listed for that template.
+- [ ] backend-endpoint and frontend-component frontmatter `version:` no longer 1.0.0; a single versioning convention is stated in one place (DEVELOPMENT-README or contributing note).
+- [ ] grep for 'v3.5.0' returns nothing in skills/nav-stats/SKILL.md.
+- [ ] skills/backend-test and skills/frontend-test contain only SKILL.md (no empty examples/functions/templates dirs); `git status` clean after removal.
+- [ ] No stray .pyc tracked under skills/*/functions/__pycache__ (or it is gitignored).
+- [ ] Sanity: invoking backend-endpoint / frontend-component mentally against the trimmed SKILL.md never directs the agent to a python3 functions/<file>.py that is absent.
+
+## Technical Decisions
+
+- **Recommendation**: `fix-now`. No blocking hook, no published JSON manifest, no knowledge-graph mutation. Changes are doc-only (SKILL.md text, frontmatter version strings) plus deletion of confirmed-empty directories. Worst case is over-trimming a step that the model could otherwise have run; mitigated by keeping the inline-fallback phrasing. The only published surface is skill frontmatter (loaded by Claude Code at session start) — version bumps are cosmetic and safe. Removing empty dirs cannot break the test skills since their SKILL.md never references those paths.
+
+## Out of Scope
+
+- Findings outside this work-package's listed scope (see TASK-42 roadmap for the full map).
+
+## Refs
+
+- TASK-42 — Audit Remediation Roadmap (umbrella)
+
+## Verify
+
+```bash
+# See Acceptance Criteria; run the relevant tests/validators before marking done.
+```
+
+## Done
+
+- [ ] All acceptance criteria checked
+- [ ] Tests pass in CI (once TASK-43 gate exists)
+- [ ] Committed + roadmap (TASK-42) status updated

--- a/.agent/tasks/TASK-51-python-misc.md
+++ b/.agent/tasks/TASK-51-python-misc.md
@@ -1,0 +1,95 @@
+# TASK-51: Misc Python correctness fixes
+
+**Status**: 📋 Planned
+**Created**: 2026-06-02
+**Work-package**: `wp11-python-misc`
+**Phase**: 4 — Independent tracks (parallel)
+**Priority**: Medium
+**Effort**: M — Five of six fixes are 1-5 line edits (regex, lstrip helper, add_goal guard, progress_tracker try/except, feature_manager shutil.which). The only one needing care is correction_to_memory: it requires reading graph_manager.add_memory to choose where the 'source' marker lives, and the count fix should ship with a test since the heuristic was structurally wrong. With three focused test files, this is ~half a day; without tests it would be S. Grouping all six in one work-package keeps it M.
+**Risk**: low — No published manifest (.claude-plugin/) is touched. No blocking hook code is modified — nav_profile_sync.py is unaffected because it self-tracks last_synced_count and calls --action sync, never the broken --action check. The correction_to_memory change does mutate knowledge-graph memory node shape (adds a 'source' field); this is additive and backward-compatible since existing memories simply lack the field and count as non-correction, but it warrants the included test. release_validator and feature_manager changes are no-ops on current data (lstrip works for ./skills paths today; the one check_command is a static literal).
+**Depends on**: none
+**Recommendation**: `fix+test`
+**Source**: audit `wf_0dc1b9ce-7d8` → plan `wf_187896bb-5af`; roadmap in TASK-42
+
+---
+
+## Summary
+
+Fix six independent small correctness defects in skill helper Python scripts (loop-variable count bug, brittle regex, unguarded JSON, shell=True under bare except, char-stripping lstrip, and missing-key assumption) and add focused unit tests for the non-trivial ones.
+
+## Findings Addressed
+
+- check_for_new_corrections counts synced memories with a condition that ignores the loop variable (correction_to_memory.py:178-181)
+- task_id_generator regex requires a description suffix, skipping plain TASK-XX.md files (task_id_generator.py:27)
+- progress_tracker reads JSON and indexes required keys without guards, crashes on corrupt/partial file (progress_tracker.py:135,180,210,213-215)
+- feature_manager runs subprocess with shell=True under a bare except that swallows interrupts (feature_manager.py:205-217)
+- release_validator uses lstrip('./') which strips characters, not the './' prefix (release_validator.py:61,111,195)
+- profile_manager.add_goal assumes every goal dict has a 'name' key (profile_manager.py:104)
+
+## Implementation
+
+All six are independent, single-file edits in skills/*/functions/*.py; none touch the published .claude-plugin manifests or any blocking hook's own code, so they can land together in one commit with tests. Concrete fixes grounded in the read code:
+
+1) correction_to_memory.py check_for_new_corrections (lines 178-181): the generator condition `'learned-from' not in str(graph.get('edges', []))` never references loop var `m`, so synced_count is uniformly len(all memories) or 0 — structurally wrong. The live sync path is NOT affected: hooks/nav_profile_sync.py tracks its own last_synced_count state file and calls `--action sync`; only the manual `--action check` CLI reaches this function. Fix per audit rec: tag correction-derived memories at creation. In _correction_to_memory_in_graph, add a source marker (add_memory currently passes source_task=None — confirm add_memory accepts/persists a source/origin field in graph_manager.add_memory before relying on it; if not, set a `source: 'correction'` field on the returned memory node). Then count `sum(1 for m in memories.values() if m.get('source') == 'correction')`. Must read skills/nav-graph/functions/graph_manager.py add_memory signature first — if it has no spare field, store the marker via the existing memory dict.
+
+2) task_id_generator.py line 27: change `rf"{prefix}-(\d+)-.*\.md"` to `rf"{prefix}-(\d+)(?:-.*)?\.md"` so both TASK-09.md and TASK-09-name.md match, aligning with graph_builder.py:146 which uses `r'TASK-(\d+)'`. Trivial one-line regex change.
+
+3) progress_tracker.py: update_progress (135), get_progress (180), get_next_task (210) call `json.loads(data_file.read_text())` then index required keys (data["progress"], data["essential_skills"], data["development_skills"], data["total"]). Wrap loads in try/except json.JSONDecodeError returning {"error": "Progress data corrupt"} (consistent with the existing missing-file {"error": ...} / {"initialized": False} returns), and use .get() with defaults for the indexed keys. get_next_task returns None on missing file — keep that contract for corrupt too.
+
+4) feature_manager.py check_installed (205-217): the only call site passes the static literal `"command -v navigator-multi-claude.sh"` (FEATURES['multi_claude_scripts'].check_command), so this is not user-tainted. Per rec, switch to shell=False with `shlex.split(check_command)` and narrow `except:` to `except (subprocess.SubprocessError, OSError, FileNotFoundError):` so KeyboardInterrupt/SystemExit propagate. Move the local `import subprocess` to module top (and add `import shlex`). Note: `command -v` is a shell builtin — with shell=False it won't resolve; switch the check to `shutil.which("navigator-multi-claude.sh") is not None` (simpler, no subprocess) OR keep check_command but invoke via `["bash","-c",cmd]`. Recommend shutil.which approach for the one installed-type feature; verify no other check_command exists (grep confirms only one).
+
+5) release_validator.py lines 61, 111, 195: replace all three `skill_path.lstrip("./")` with a helper `_strip_dot_slash(p) -> p[2:] if p.startswith("./") else p`. Current plugin.json paths are all `./skills/...` so lstrip happens to work today (latent bug), but it would corrupt any path with a leading-dot segment. Add the helper once, use in check_skills_exist, check_skills_committed, verify_tag_contents.
+
+6) profile_manager.py add_goal line 104: `next((g for g in profile["goals"] if g["name"] == goal["name"]), None)` raises KeyError/TypeError if goal lacks 'name' or a legacy stored goal lacks 'name'. Per rec: guard at top `if not goal.get("name"): return {"error": "goal requires a 'name'"}` (or raise ValueError caught by caller) and use `g.get("name")` in the comparison. Note caller at line 256 ignores return value and main prints goal.get('name','Unknown'); decide on raise-vs-error-dict to match how main consumes it (main currently treats add_goal as returning the profile, then saves — so prefer guarding and returning profile unchanged plus stderr, or raise before save). Keep return type as dict (profile) to not break the save_profile(...) call.
+
+Tests: there is no pytest run in CI (release.yml has no test step) but sibling skills follow a test_*.py convention (e.g. nav-loop/functions/test_*.py, nav-workflow/functions/test_*.py run via plain python3). Add test_*.py next to each non-trivial fix (correction_to_memory, progress_tracker, release_validator) following that convention.
+
+### Files
+
+| File | Change |
+| --- | --- |
+| `skills/nav-graph/functions/correction_to_memory.py` | Tag correction-derived memories with a source marker and fix check_for_new_corrections to count m.get('source')=='correction' (lines 178-181) |
+| `skills/nav-graph/functions/graph_manager.py` | Verify/extend add_memory so a 'source' marker can be persisted on the memory node (read first; extend only if no existing field works) |
+| `skills/nav-task/functions/task_id_generator.py` | Loosen regex line 27 to TASK-(\d+)(?:-.*)?\.md so plain TASK-XX.md is counted |
+| `skills/nav-onboard/functions/progress_tracker.py` | Guard json.loads with try/except JSONDecodeError and use .get() defaults in update_progress/get_progress/get_next_task (135,180,210,213-215) |
+| `skills/nav-features/functions/feature_manager.py` | Replace shell=True check_installed with shutil.which (or shell=False + shlex.split) and narrow bare except to (SubprocessError, OSError); hoist imports |
+| `skills/nav-release/functions/release_validator.py` | Add _strip_dot_slash helper and replace the three lstrip('./') calls (lines 61,111,195) |
+| `skills/nav-profile/functions/profile_manager.py` | Guard add_goal for missing 'name' and use g.get('name') in the dedup comparison (line 104) |
+| `skills/nav-graph/functions/test_correction_to_memory.py` | New: unit test for synced-count after sync and for empty/no-correction graph |
+| `skills/nav-onboard/functions/test_progress_tracker.py` | New: unit test that corrupt/partial .progress-data.json returns an error dict, not a crash |
+| `skills/nav-release/functions/test_release_validator.py` | New: unit test that _strip_dot_slash handles './skills/x', 'skills/x', and a leading-dot segment correctly |
+
+## Acceptance Criteria
+
+- [ ] correction_to_memory.py: after sync_corrections_to_graph adds N memories, check_for_new_corrections reports synced_memories == N and pending == 0 (test asserts this on a temp profile+graph)
+- [ ] Existing non-correction memories (no source field) are NOT counted as synced
+- [ ] task_id_generator: get_next_task_id counts both TASK-09.md and TASK-09-name.md (test or manual: a dir with only TASK-09.md returns TASK-10, not TASK-01)
+- [ ] progress_tracker: update_progress/get_progress/get_next_task on a corrupt or partial .progress-data.json return an {"error":...} dict (or None for get_next_task) instead of raising JSONDecodeError/KeyError
+- [ ] feature_manager: check_installed uses no shell=True; KeyboardInterrupt is no longer swallowed; multi_claude_scripts feature still reports installed/not-installed correctly
+- [ ] release_validator: _strip_dot_slash('./skills/x')=='skills/x', ('skills/x')=='skills/x', ('./a/.b')=='a/.b'; --check-all still passes against current plugin.json
+- [ ] profile_manager: add_goal with a goal dict lacking 'name' returns/raises a clear error and does not crash; legacy goals without 'name' do not break dedup
+- [ ] All new test_*.py files pass via `python3 <test_file>`
+
+## Technical Decisions
+
+- **Recommendation**: `fix+test`. No published manifest (.claude-plugin/) is touched. No blocking hook code is modified — nav_profile_sync.py is unaffected because it self-tracks last_synced_count and calls --action sync, never the broken --action check. The correction_to_memory change does mutate knowledge-graph memory node shape (adds a 'source' field); this is additive and backward-compatible since existing memories simply lack the field and count as non-correction, but it warrants the included test. release_validator and feature_manager changes are no-ops on current data (lstrip works for ./skills paths today; the one check_command is a static literal).
+
+## Out of Scope
+
+- Findings outside this work-package's listed scope (see TASK-42 roadmap for the full map).
+
+## Refs
+
+- TASK-42 — Audit Remediation Roadmap (umbrella)
+
+## Verify
+
+```bash
+# See Acceptance Criteria; run the relevant tests/validators before marking done.
+```
+
+## Done
+
+- [ ] All acceptance criteria checked
+- [ ] Tests pass in CI (once TASK-43 gate exists)
+- [ ] Committed + roadmap (TASK-42) status updated

--- a/.agent/tasks/TASK-52-docs-config.md
+++ b/.agent/tasks/TASK-52-docs-config.md
@@ -1,0 +1,91 @@
+# TASK-52: Docs & config drift cleanup
+
+**Status**: 📋 Planned
+**Created**: 2026-06-02
+**Work-package**: `wp9-docs-config`
+**Phase**: 5 — Docs & config reconciliation
+**Priority**: Low
+**Effort**: M — Mostly trivial one-line string edits (README counts, CLAUDE.md version/token/command, manifest emails, DEVELOPMENT-README TASK-40 — each <5 min). Two items carry the bulk: the version-management SOP rewrite (SSOT map + ~90-line embedded bash audit script, must be re-grounded against the real manifests) and the config_migrator VERSION_CONFIGS extension (~11 new blocks copied verbatim from live .nav-config.json, plus a migration test to confirm idempotent additive behavior). Total well under a half-day; no exploration needed since all facts are now verified.
+**Risk**: low — No blocking hook or runtime control flow touched. config_migrator change is additive (get_missing_configs only inserts keys absent from a user's config; version guard at line 166 prevents downgrades) — worst case a brand-new default block lands in an existing user's config, which is the intended behavior. session_start_hook addition to .nav-config.json is read defensively via .get with safe defaults, so it cannot break the SessionStart hook. The email change touches both published manifests (plugin.json + marketplace.json ship to every install) but is a metadata-only string with no functional effect. README/CLAUDE.md/SOP edits are docs-only.
+**Depends on**: TASK-44 (wp2-version-tooling)
+**Recommendation**: `fix+test`
+**Source**: audit `wf_0dc1b9ce-7d8` → plan `wf_187896bb-5af`; roadmap in TASK-42
+
+---
+
+## Summary
+
+Reconcile every stale version/skill-count/config reference and dead command across CLAUDE.md, README.md, DEVELOPMENT-README.md, the version-management SOP, the plugin manifests, and config_migrator so the docs match the v6.15.6 shipping reality and stop drifting each release.
+
+## Findings Addressed
+
+- README contradicts itself on skill count (27 line 98 vs 19 line 170); actual registered count is 29
+- CLAUDE.md config sample pins version 5.5.0 (line 923) and omits all v6.x feature blocks (lines 921-938)
+- config_migrator.py VERSION_CONFIGS stops at 5.6.0 (lines 57-80) so no v5.x/v6.x block (tom_features, loop_mode, knowledge_graph, multi_agent, the *_hook toggles) is ever seeded on upgrade
+- session_start_hook block is absent from .agent/.nav-config.json; nav_session_start.py:255 reads it via .get with safe defaults (no runtime bug) but the documented opt-out is undiscoverable
+- version-management SOP references a marketplace plugins[0].version field and README status/roadmap/footer lines (SOP lines 31-64, 108-120, 132-220) that do not exist in the current manifests/README
+- Placeholder email aleks@example.com shipped in both .claude-plugin/plugin.json author.email (line 7) and .claude-plugin/marketplace.json owner.email (line 6)
+- CLAUDE.md advertises legacy slash command /nav:update-doc (line 852) which has no backing skill
+- CLAUDE.md overstates its own token cost as ~15k (line 879); actual file is 28,120 chars (~7k tokens)
+- DEVELOPMENT-README lists TASK-40 as an active in-flight thread (line 150) but it is archived at .agent/tasks/archive/TASK-40-phase-3-hook-migration-v6.12.md
+- DEVELOPMENT-README says 6-file bump checklist (lines 166, 233) while the linked version-management SOP says 9 locations; reconcile to one authoritative list
+
+**Already resolved in v6.15.6** (excluded from this work):
+- ~~v6.15.6 removed the deleted nav_commit_reminder.py PostToolUse(Bash) block from .claude-plugin/plugin.json (both the 'high' and duplicate 'critical' findings for plugin.json:139-148 are resolved; current line 139 onward is the nav_task_graph_sync group)~~
+- ~~v6.15.6 synced DEVELOPMENT-README.md version references at lines 81, 182, 289 to v6.15.6 (the v6.15.3 'frozen' finding and the medium 'states v6.15.3' finding are resolved); the v6.15.4/v6.15.5 summaries also live in marketplace.json breaking_changes~~
+- ~~v6.15.6 deleted the nav_commit_reminder.py row from the DEVELOPMENT-README hook table and corrected 'ten hooks' to 'nine' (DEVELOPMENT-README.md:198 finding resolved; token_monitor.py is still present and correctly marked '(legacy)')~~
+- ~~README.md version badge at line 8 is already v6.15.6 (the SOP's phantom README status/roadmap/footer version lines never existed, so there is nothing else to bump in README for version)~~
+- ~~CLAUDE.md footer is already synced to Navigator Version 6.15.6~~
+
+## Implementation
+
+All changes are doc/config string edits plus one small Python dict extension; no shipped runtime control flow changes. (1) README.md: change line 98 '✅ 27 skills' and line 170 '**19 skills**' to a single non-numeric phrasing ('full skill suite' / 'skills that auto-invoke') so the count cannot drift, since the manifest skills array (verified 29 entries, 1:1 with skills/*/ dirs) is the source of truth. (2) CLAUDE.md: bump the config sample version literal 5.5.0 to 6.15.6 at line 923 and add a one-line note that the sample is a minimal subset (the live .nav-config.json carries tom_features/loop_mode/knowledge_graph/multi_agent/*_hook blocks); fix the '~15k' token figure at line 879 to '~7k' (verified 28,120 chars); remove '/nav:update-doc' from line 852 (no nav-update-doc skill dir exists; grep hits are only plugin-slash-command example files) and map the intent to nav-task/nav-sop. (3) config_migrator.py: extend VERSION_CONFIGS (lines 57-80) with keys for 5.0.0 (tom_features), 5.1.0 (loop_mode), 6.0.0 (knowledge_graph), 6.1.0 (multi_agent), and the lifecycle-hook toggle blocks (compact_hook, task_graph_sync_hook, workflow_state_hook, profile_sync_hook, workflow_enforcer_hook, read_guard_hook, session_start_hook) keyed at their introduction versions, copying the exact default shapes from the live .agent/.nav-config.json so existing users get discoverable opt-out keys on upgrade — the existing get_missing_configs loop (lines 107-114) already only adds keys absent from config, so this is purely additive and idempotent. (4) .agent/.nav-config.json: add a session_start_hook block ({enabled:true, include_sections:[...], char_budget:...}) mirroring nav_session_start.py:256-263 defaults so the documented opt-out is present. (5) version-management.md: rewrite the Single Source of Truth + Version Reference Map (lines 29-64) and the embedded audit script (lines 132-220) to drop the dead plugins[0].version row (marketplace.json has only metadata.version + plugins[].name/source — verified) and the phantom README status/roadmap/footer lines, replacing with the real locations (marketplace.json metadata.version, plugin.json version, README badge line ~8, CLAUDE.md footer + config sample, .nav-config.json version, DEVELOPMENT-README footer); update SOP Created/Last-Updated dates. (6) Both manifests: replace aleks@example.com with the real maintainer contact (confirm address with maintainer before edit). (7) DEVELOPMENT-README.md: drop TASK-40 from the active list at line 150 (it is archived) and refresh the 'as of 2026-05-18' date; reconcile the '6-file bump checklist' (lines 166, 233) and the SOP to one authoritative file set — the DEVELOPMENT-README 6-file list is closer to reality, so update the SOP to match it.
+
+### Files
+
+| File | Change |
+| --- | --- |
+| `README.md` | Lines 98 + 170: replace '27 skills' and '19 skills' with a single non-numeric phrasing (manifest is SSOT for count) |
+| `CLAUDE.md` | Line 923 sample version 5.5.0 -> 6.15.6 + minimal-subset note; line 879 '~15k' -> '~7k'; line 852 remove /nav:update-doc |
+| `skills/nav-sync-claude/functions/config_migrator.py` | Extend VERSION_CONFIGS (57-80) with v5.0/5.1/6.0/6.1 feature blocks + all lifecycle-hook toggle blocks incl. session_start_hook, copying live config defaults |
+| `.agent/.nav-config.json` | Add session_start_hook block mirroring nav_session_start.py defaults (enabled/include_sections/char_budget) |
+| `.agent/sops/development/version-management.md` | Rewrite SSOT + Version Reference Map (29-64) and audit script (132-220): drop phantom plugins[0].version and README status/roadmap/footer lines; list the real 6 locations; refresh dates |
+| `.claude-plugin/plugin.json` | Line 7 author.email: replace placeholder aleks@example.com with real maintainer contact |
+| `.claude-plugin/marketplace.json` | Line 6 owner.email: replace placeholder aleks@example.com with real maintainer contact |
+| `.agent/DEVELOPMENT-README.md` | Line 150: remove archived TASK-40 from active list + refresh 'as of' date; reconcile 6-file checklist wording (166, 233) with the rewritten SOP |
+
+## Acceptance Criteria
+
+- [ ] grep -nE '27 skills|19 skills' README.md returns nothing; README no longer hardcodes a skill count
+- [ ] CLAUDE.md config sample shows "version": "6.15.6" and is labelled a minimal subset; the ~15k token figure is corrected to ~7k; /nav:update-doc no longer appears in CLAUDE.md
+- [ ] config_migrator VERSION_CONFIGS contains tom_features, loop_mode, knowledge_graph, multi_agent, and all *_hook toggle blocks (incl. session_start_hook) keyed by introduction version; a unit/regression test migrates a synthetic v5.3.0 config and asserts all v5.x/v6.x blocks are seeded and a second run is a no-op (idempotent)
+- [ ] .agent/.nav-config.json contains a session_start_hook block; python3 hooks/nav_session_start.py still emits its payload unchanged with the block present (smoke test)
+- [ ] version-management.md Version Reference Map lists only locations that exist (no plugins[0].version, no README status/roadmap/footer lines); the embedded audit script run against the repo at v6.15.6 exits 0 with zero ERRORS
+- [ ] neither .claude-plugin/plugin.json nor .claude-plugin/marketplace.json contains aleks@example.com (grep -r 'aleks@example.com' .claude-plugin returns nothing)
+- [ ] DEVELOPMENT-README.md active task list does not include TASK-40; the bump-checklist count is consistent between DEVELOPMENT-README and version-management.md
+- [ ] json.load succeeds on both manifests and .nav-config.json after edits (no JSON syntax breakage)
+
+## Technical Decisions
+
+- **Recommendation**: `fix+test`. No blocking hook or runtime control flow touched. config_migrator change is additive (get_missing_configs only inserts keys absent from a user's config; version guard at line 166 prevents downgrades) — worst case a brand-new default block lands in an existing user's config, which is the intended behavior. session_start_hook addition to .nav-config.json is read defensively via .get with safe defaults, so it cannot break the SessionStart hook. The email change touches both published manifests (plugin.json + marketplace.json ship to every install) but is a metadata-only string with no functional effect. README/CLAUDE.md/SOP edits are docs-only.
+
+## Out of Scope
+
+- Findings outside this work-package's listed scope (see TASK-42 roadmap for the full map).
+
+## Refs
+
+- TASK-42 — Audit Remediation Roadmap (umbrella)
+- TASK-44 — dependency (`wp2-version-tooling`)
+
+## Verify
+
+```bash
+# See Acceptance Criteria; run the relevant tests/validators before marking done.
+```
+
+## Done
+
+- [ ] All acceptance criteria checked
+- [ ] Tests pass in CI (once TASK-43 gate exists)
+- [ ] Committed + roadmap (TASK-42) status updated

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,44 @@ permissions:
   contents: write
 
 jobs:
+  validate:
+    name: Validate release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Run unit tests
+        run: make test
+
+      - name: Validate plugin integrity (skills exist, committed, versions consistent)
+        run: python3 skills/nav-release/functions/release_validator.py --check-all
+
+      - name: Verify every manifest hook path resolves to a file
+        # Guards the v6.15.6 regression class: a deleted hook left registered in plugin.json.
+        run: python3 skills/nav-release/functions/release_validator.py --verify-hook-paths
+
+      - name: Verify all version files match the pushed tag
+        run: python3 skills/nav-release/functions/release_validator.py --check-version "${{ steps.version.outputs.version }}"
+
+      - name: Verify tag contains all skills
+        run: python3 skills/nav-release/functions/release_validator.py --verify-tag "${GITHUB_REF#refs/tags/}"
+
   release:
     name: Create GitHub Release
+    needs: validate
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    name: Python unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run unit tests
+        # `make test` runs per-directory unittest discovery across all genuine
+        # suites (see Makefile TEST_DIRS) — same command used locally.
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,32 @@ build:
 	@python3 -m py_compile skills/nav-loop/functions/status_generator.py && echo "status_generator.py: OK"
 	@echo "Build validation complete."
 
-# Test target - run Jest tests for TypeScript and Python unit tests
+# Directories with genuine unittest suites. Each test_*.py imports its sibling
+# module by bare name, so discovery must run per-directory (from inside each dir).
+# Deliberately EXCLUDES two files that match test_*.py but are NOT unit tests:
+#   skills/frontend-component/functions/test_generator.py  (an argparse CLI generator)
+#   skills/product-design/functions/test_mcp_connection.py (a live Figma MCP probe)
+TEST_DIRS := \
+	skills/nav-upgrade/functions \
+	skills/nav-sync-claude/functions \
+	skills/nav-simplify/scripts \
+	skills/nav-workflow/functions \
+	skills/nav-init/functions \
+	skills/nav-loop/functions \
+	skills/nav-release/functions
+
+# Test target - run all Python unit tests via per-directory discovery
 test:
-	@echo "Running tests..."
-	@if [ -f "package-lock.json" ] || [ -d "node_modules" ]; then \
-		npx jest --passWithNoTests 2>/dev/null || true; \
-	fi
-	@python3 -c "exec(open('skills/nav-loop/functions/status_generator.py').read())" 2>/dev/null && echo "Python module loads: OK"
-	@echo "Tests complete."
+	@echo "Running unit tests..."
+	@fail=0; \
+	for d in $(TEST_DIRS); do \
+		if ls $$d/test_*.py >/dev/null 2>&1; then \
+			echo "--- $$d ---"; \
+			( cd $$d && python3 -m unittest discover -p "test_*.py" ) || fail=1; \
+		fi; \
+	done; \
+	if [ $$fail -ne 0 ]; then echo "TESTS FAILED"; exit 1; fi; \
+	echo "All unit tests passed."
 
 # Lint target - check code style
 lint:

--- a/skills/nav-release/functions/release_validator.py
+++ b/skills/nav-release/functions/release_validator.py
@@ -394,6 +394,59 @@ def verify_hooks(root: Path, plugin: dict) -> Tuple[List[Dict], List[Dict]]:
     return passed, failed
 
 
+def verify_hook_paths(root: Path, plugin: dict) -> Tuple[List[str], List[str]]:
+    """
+    Statically assert every hook command in plugin.json references a
+    hooks/<name>.py file that exists on disk.
+
+    Catches the v6.15.5/v6.15.6 regression class: a deleted hook left
+    registered in the published manifest. verify_hooks() runs the command,
+    but a missing-file PostToolUse hook exits 2 and is classified 'pass'
+    (PostToolUse is silent-by-design), so a static existence check is a
+    required separate gate.
+
+    Returns:
+        (resolved, missing) — resolved are "event: hooks/<name>" strings;
+        missing are the offending full command strings.
+    """
+    hooks = plugin.get("hooks", {})
+    resolved: List[str] = []
+    missing: List[str] = []
+
+    for event, entries in hooks.items():
+        for entry in entries:
+            for hook in entry.get("hooks", []):
+                cmd = hook.get("command", "")
+                match = re.search(r"/hooks/(\w+\.py)", cmd)
+                if not match:
+                    continue
+                name = match.group(1)
+                if (root / "hooks" / name).exists():
+                    resolved.append(f"{event}: hooks/{name}")
+                else:
+                    missing.append(f"{event}: {cmd}")
+
+    return resolved, missing
+
+
+def check_version_match(root: Path, expected: str) -> Tuple[Dict[str, str], List[str]]:
+    """
+    Compare an expected version (e.g. a release tag) against every
+    version-bearing file. Strips a single leading 'v' from the tag.
+
+    Returns:
+        (versions, mismatches) — mismatches are "file=found" strings for any
+        file whose version != expected.
+    """
+    if expected.startswith("v"):
+        expected = expected[1:]
+    versions = check_version_consistency(root)
+    mismatches = [
+        f"{name}={ver}" for name, ver in versions.items() if ver != expected
+    ]
+    return versions, mismatches
+
+
 def main():
     parser = argparse.ArgumentParser(description="Validate Navigator plugin for release")
     parser.add_argument("--check-all", action="store_true", help="Run all validation checks")
@@ -401,6 +454,8 @@ def main():
     parser.add_argument("--verify-tag", type=str, help="Verify tag contains all skills")
     parser.add_argument("--verify-hooks", action="store_true",
                         help="Smoke-test plugin manifest hook commands under set/unset CLAUDE_PLUGIN_DIR")
+    parser.add_argument("--verify-hook-paths", action="store_true",
+                        help="Statically assert every plugin.json hook command resolves to an existing hooks/<name>.py file")
     parser.add_argument("--json", action="store_true", help="Output as JSON")
 
     args = parser.parse_args()
@@ -427,6 +482,37 @@ def main():
                 print(f"  ✓  {chk['event']:18} [{chk['env_state']:5}] "
                       f"exit={chk['exit_code']} out={chk['stdout_len']}B err={chk['stderr_len']}B")
         return 0 if not failed else 1
+
+    if args.verify_hook_paths:
+        resolved, missing = verify_hook_paths(root, plugin)
+        if args.json:
+            print(json.dumps({"resolved": resolved, "missing": missing}, indent=2))
+        else:
+            total = len(resolved) + len(missing)
+            print(f"Hook-path check: {len(resolved)}/{total} resolve to an existing file")
+            for r in resolved:
+                print(f"  ✓  {r}")
+            for m in missing:
+                print(f"  ❌ MISSING FILE — {m}")
+            if missing:
+                print(f"\nVALIDATION: FAILED ✗ — {len(missing)} hook command(s) reference a deleted/missing script")
+        return 0 if not missing else 1
+
+    if args.check_version:
+        versions, mismatches = check_version_match(root, args.check_version)
+        expected = args.check_version.lstrip("v") if args.check_version.startswith("v") else args.check_version
+        if args.json:
+            print(json.dumps({"expected": expected, "versions": versions, "mismatches": mismatches}, indent=2))
+        else:
+            print(f"Version-match check (expected {expected}):")
+            for name, ver in versions.items():
+                indicator = "✓" if ver == expected else "← MISMATCH"
+                print(f"  {name:<20} {ver} {indicator}")
+            if mismatches:
+                print(f"\nVALIDATION: FAILED ✗ — {len(mismatches)} file(s) disagree with {expected}: {', '.join(mismatches)}")
+            else:
+                print(f"\nVALIDATION: PASSED ✓ — all files at {expected}")
+        return 0 if not mismatches else 1
 
     if args.verify_tag:
         found, missing = verify_tag_contents(root, args.verify_tag)

--- a/skills/nav-release/functions/test_release_validator.py
+++ b/skills/nav-release/functions/test_release_validator.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Unit tests for release_validator's static gates (verify_hook_paths, check_version_match).
+
+These guard the v6.15.6 regression class: a deleted hook left registered in the
+published manifest, and version drift across the bump files.
+"""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from release_validator import verify_hook_paths, check_version_match  # noqa: E402
+
+
+def _make_root(tmp: Path, hook_names, manifest_hooks):
+    """Build a minimal project root: hooks/ with the given files + a plugin.json."""
+    (tmp / ".claude-plugin").mkdir(parents=True)
+    (tmp / "hooks").mkdir()
+    for name in hook_names:
+        (tmp / "hooks" / name).write_text("# stub\n")
+    (tmp / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "navigator", "version": "6.15.6", "hooks": manifest_hooks})
+    )
+
+
+def _cmd(name):
+    return {
+        "type": "command",
+        "command": f'python3 "${{CLAUDE_PLUGIN_DIR:-x}}/hooks/{name}"',
+        "timeout": 5,
+    }
+
+
+class VerifyHookPathsTest(unittest.TestCase):
+    def test_all_hooks_resolve(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            _make_root(
+                tmp,
+                ["a.py", "b.py"],
+                {"SessionStart": [{"hooks": [_cmd("a.py")]}],
+                 "Stop": [{"hooks": [_cmd("b.py")]}]},
+            )
+            plugin = json.loads((tmp / ".claude-plugin" / "plugin.json").read_text())
+            resolved, missing = verify_hook_paths(tmp, plugin)
+            self.assertEqual(missing, [])
+            self.assertEqual(len(resolved), 2)
+
+    def test_deleted_hook_is_flagged(self):
+        # The exact v6.15.6 regression: a registered hook file does not exist.
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            _make_root(
+                tmp,
+                ["a.py"],
+                {"SessionStart": [{"hooks": [_cmd("a.py")]}],
+                 "PostToolUse": [{"matcher": "Bash",
+                                  "hooks": [_cmd("nav_commit_reminder.py")]}]},
+            )
+            plugin = json.loads((tmp / ".claude-plugin" / "plugin.json").read_text())
+            resolved, missing = verify_hook_paths(tmp, plugin)
+            self.assertEqual(len(missing), 1)
+            self.assertIn("nav_commit_reminder.py", missing[0])
+
+    def test_command_without_hook_path_is_ignored(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            _make_root(
+                tmp, ["a.py"],
+                {"Stop": [{"hooks": [{"type": "command", "command": "echo hi"}]}]},
+            )
+            plugin = json.loads((tmp / ".claude-plugin" / "plugin.json").read_text())
+            resolved, missing = verify_hook_paths(tmp, plugin)
+            self.assertEqual(missing, [])
+            self.assertEqual(resolved, [])
+
+
+class CheckVersionMatchTest(unittest.TestCase):
+    def _root_with_versions(self, tmp, version):
+        (tmp / ".claude-plugin").mkdir(parents=True)
+        (tmp / ".agent").mkdir()
+        (tmp / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps({"version": version}))
+        (tmp / ".claude-plugin" / "marketplace.json").write_text(
+            json.dumps({"metadata": {"version": version}}))
+        (tmp / "CLAUDE.md").write_text(f"**Navigator Version**: {version}\n")
+        (tmp / "README.md").write_text(
+            f"[![Version](https://img.shields.io/badge/version-{version}-blue.svg)](x)\n")
+        (tmp / ".agent" / ".nav-config.json").write_text(
+            json.dumps({"version": version}))
+
+    def test_all_match(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            self._root_with_versions(tmp, "6.15.6")
+            _, mismatches = check_version_match(tmp, "6.15.6")
+            self.assertEqual(mismatches, [])
+
+    def test_tag_prefix_stripped(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            self._root_with_versions(tmp, "6.15.6")
+            _, mismatches = check_version_match(tmp, "v6.15.6")
+            self.assertEqual(mismatches, [])
+
+    def test_drift_is_flagged(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            self._root_with_versions(tmp, "6.15.6")
+            # Simulate one file left behind (README badge stale).
+            (tmp / "README.md").write_text(
+                "[![Version](https://img.shields.io/badge/version-6.15.5-blue.svg)](x)\n")
+            _, mismatches = check_version_match(tmp, "6.15.6")
+            self.assertTrue(any("README.md" in m for m in mismatches))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Files the verified project audit into a phased remediation plan and implements the keystone (wp1: CI test + pre-publish validation gate).

### Background
A 10-dimension, adversarially-verified audit (`wf_0dc1b9ce-7d8`) confirmed **86 findings**. The one **critical** finding — `plugin.json` still registering the deleted `nav_commit_reminder.py` hook (a per-Bash-call error for every installed user) — was already hotfixed and shipped as **v6.15.6** on `main`. This PR addresses the systemic gap that let it ship.

### Planning artifacts
- **TASK-42** — umbrella remediation roadmap (5 phases, critical path `wp1 → wp4 → wp6`)
- **TASK-43…52** — one task doc per work-package; **wp10** linked into existing **TASK-25**

### wp1 — CI gate (TASK-43) — the keystone
Before this PR, `release.yml` ran **zero tests** and no integrity checks; `make test` was a no-op. That is exactly how the v6.15.5 regression shipped.

- `.github/workflows/test.yml` — runs all **239** unit tests on push/PR
- `release.yml` — new `validate` job; `release` now `needs: validate`. Runs `make test` + `release_validator --check-all / --verify-hook-paths / --check-version <tag> / --verify-tag` before any `gh release create`
- `release_validator.py` — new `verify_hook_paths()` (+`--verify-hook-paths`) statically asserts every manifest hook command resolves to a real `hooks/<name>.py`; wired the previously declared-but-undispatched `--check-version` to compare a tag against all 5 version files
- `Makefile` — rewrote the no-op `test` target to per-directory `unittest` discovery (excludes the two non-test `test_*.py` files)
- `test_release_validator.py` — 6 tests incl. a **regression test**: re-adding a `nav_commit_reminder.py` block fails `--verify-hook-paths`

### Verified locally
- 239 tests pass via `make test`
- `--verify-hook-paths`: 9/9 resolve; poisoned manifest → FAIL exit 1
- `--check-version`: matches at 6.15.6, fails at 9.9.9, strips `v` prefix
- `--check-all` passes on clean tree

## Remaining (not in this PR)
Phase 1 also includes **wp2** (version tooling) and **wp8** (skill templates). Phases 2–5 cover test coverage, hook/graph/detection fixes, path resolution, multi-Claude (TASK-25), and docs. **Security re-sweep (wp12) still owed** — noted as an open gap in TASK-42.