### PR TITLE
Skill template/reference integrity (TASK-50, wp8)

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -1,9 +1,9 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-06-02T21:50:07.789359Z",
+  "last_updated": "2026-06-03T10:53:49.138892Z",
   "stats": {
-    "total_nodes": 130,
-    "total_edges": 860,
+    "total_nodes": 131,
+    "total_edges": 869,
     "memory_count": 37
   },
   "nodes": {
@@ -554,6 +554,22 @@
           "knowledge",
           "authentication",
           "deployment"
+        ]
+      },
+      "TASK-50": {
+        "path": "/Users/aleks.petrov/Projects/startups/navigator/.agent/tasks/TASK-50-skill-templates.md",
+        "title": "Skill template/reference integrity",
+        "status": "completed",
+        "concepts": [
+          "testing",
+          "knowledge",
+          "skills",
+          "api",
+          "frontend",
+          "deployment",
+          "tom",
+          "authentication",
+          "database"
         ]
       }
     },
@@ -6626,6 +6642,51 @@
       "from": "TASK-44",
       "to": "authentication",
       "type": "implements"
+    },
+    {
+      "from": "TASK-50",
+      "to": "knowledge",
+      "type": "implements"
+    },
+    {
+      "from": "TASK-50",
+      "to": "authentication",
+      "type": "implements"
+    },
+    {
+      "from": "TASK-50",
+      "to": "testing",
+      "type": "implements"
+    },
+    {
+      "from": "TASK-50",
+      "to": "skills",
+      "type": "implements"
+    },
+    {
+      "from": "TASK-50",
+      "to": "frontend",
+      "type": "implements"
+    },
+    {
+      "from": "TASK-50",
+      "to": "deployment",
+      "type": "implements"
+    },
+    {
+      "from": "TASK-50",
+      "to": "database",
+      "type": "implements"
+    },
+    {
+      "from": "TASK-50",
+      "to": "tom",
+      "type": "implements"
+    },
+    {
+      "from": "TASK-50",
+      "to": "api",
+      "type": "implements"
     }
   ],
   "concept_index": {
@@ -6660,7 +6721,8 @@
       "mem-012",
       "TASK-38",
       "TASK-41",
-      "TASK-40"
+      "TASK-40",
+      "TASK-50"
     ],
     "testing": [
       "TASK-32",
@@ -6735,7 +6797,8 @@
       "TASK-38",
       "TASK-41",
       "TASK-40",
-      "TASK-44"
+      "TASK-44",
+      "TASK-50"
     ],
     "context": [
       "TASK-32",
@@ -6893,7 +6956,8 @@
       "TASK-38",
       "TASK-41",
       "TASK-40",
-      "TASK-44"
+      "TASK-44",
+      "TASK-50"
     ],
     "session": [
       "TASK-32",
@@ -6965,7 +7029,8 @@
       "before-compact-2025-01-23-task35-knowledge-graph",
       "2025-01-21-task30-verification-plan",
       "TASK-41",
-      "TASK-44"
+      "TASK-44",
+      "TASK-50"
     ],
     "workflow": [
       "TASK-33",
@@ -7079,7 +7144,8 @@
       "2025-10-19T18-15-v2.0-foundation-complete",
       "2025-10-19-195740-v2.3-release-complete",
       "2025-10-19-200824-v2.3.0-complete",
-      "2025-10-20-092541-v3.0.0-migration-complete"
+      "2025-10-20-092541-v3.0.0-migration-complete",
+      "TASK-50"
     ],
     "api": [
       "TASK-01",
@@ -7114,7 +7180,8 @@
       "TASK-38",
       "TASK-41",
       "TASK-40",
-      "TASK-44"
+      "TASK-44",
+      "TASK-50"
     ],
     "markers": [
       "TASK-18",
@@ -7198,7 +7265,8 @@
       "TASK-38",
       "TASK-41",
       "TASK-40",
-      "TASK-44"
+      "TASK-44",
+      "TASK-50"
     ],
     "code quality": [
       "TASK-19",
@@ -7234,7 +7302,8 @@
       "TASK-38",
       "TASK-41",
       "TASK-40",
-      "TASK-44"
+      "TASK-44",
+      "TASK-50"
     ],
     "theory of mind": [
       "TASK-19",
@@ -7353,7 +7422,8 @@
       "TASK-38",
       "TASK-41",
       "TASK-40",
-      "TASK-44"
+      "TASK-44",
+      "TASK-50"
     ],
     "general": [
       "mem-028",

--- a/.agent/tasks/TASK-50-skill-templates.md
+++ b/.agent/tasks/TASK-50-skill-templates.md
@@ -1,6 +1,6 @@
 # TASK-50: Skill template/reference integrity
 
-**Status**: 📋 Planned
+**Status**: ✅ Implemented — 2026-06-03
 **Created**: 2026-06-02
 **Work-package**: `wp8-skill-templates`
 **Phase**: 1 — Gate + zero-dep quick wins
@@ -60,13 +60,19 @@ backend-test / frontend-test: `git rm` the empty examples/, functions/, template
 
 ## Acceptance Criteria
 
-- [ ] Every functions/templates/examples path referenced in backend-endpoint/SKILL.md and frontend-component/SKILL.md resolves to a file that exists on disk (verify with a script that greps `functions/`, `templates/`, `examples/` references and stats each).
-- [ ] express-route-template.ts placeholder list in SKILL.md (around line 486) lists exactly the placeholders present in templates/express-route-template.ts: ${ROUTE_PATH}, ${HTTP_METHOD}, ${RESOURCE_NAME}, ${RESOURCE_NAME_LOWER}, ${HTTP_METHOD_LOWER}, ${MIDDLEWARE_BLOCK}; no ${VALIDATION_MIDDLEWARE}/${AUTH_MIDDLEWARE} listed for that template.
-- [ ] backend-endpoint and frontend-component frontmatter `version:` no longer 1.0.0; a single versioning convention is stated in one place (DEVELOPMENT-README or contributing note).
-- [ ] grep for 'v3.5.0' returns nothing in skills/nav-stats/SKILL.md.
-- [ ] skills/backend-test and skills/frontend-test contain only SKILL.md (no empty examples/functions/templates dirs); `git status` clean after removal.
-- [ ] No stray .pyc tracked under skills/*/functions/__pycache__ (or it is gitignored).
-- [ ] Sanity: invoking backend-endpoint / frontend-component mentally against the trimmed SKILL.md never directs the agent to a python3 functions/<file>.py that is absent.
+- [x] Every functions/templates/examples path referenced in backend-endpoint/SKILL.md and frontend-component/SKILL.md resolves to a file that exists on disk (verified via a grep+stat script — 21 refs, all resolve).
+- [x] express-route-template.ts placeholder list in SKILL.md lists exactly the placeholders present in templates/express-route-template.ts (${ROUTE_PATH}, ${HTTP_METHOD}, ${HTTP_METHOD_LOWER}, ${RESOURCE_NAME}, ${RESOURCE_NAME_LOWER}, ${MIDDLEWARE_BLOCK}); ${VALIDATION_MIDDLEWARE}/${AUTH_MIDDLEWARE} removed (set-equal check passed).
+- [x] backend-endpoint and frontend-component frontmatter `version:` bumped 1.0.0 → 2.0.0; versioning convention stated in new root `CONTRIBUTING.md` (per-skill semver, independent of plugin version).
+- [x] grep for 'v3.5.0' returns nothing in skills/nav-stats/SKILL.md (string replaced with version-neutral "reinstall/update Navigator" message; owns only the string — the cwd-path check at line 46 stays for wp3).
+- [x] skills/backend-test and skills/frontend-test contain only SKILL.md; empty dirs removed. (NOTE: they were untracked filesystem scaffold — git only tracked SKILL.md — so they never shipped; `rmdir` is local cleanup, no git delta.)
+- [x] No stray .pyc tracked — already clean: `__pycache__/` is gitignored (.gitignore:64) and `git ls-files` shows zero tracked pyc. No action needed.
+- [x] Sanity: trimmed SKILL.md never directs the agent to an absent `python3 functions/<file>.py` (error_handler_generator/test_generator invocations in backend-endpoint replaced with inline-write guidance).
+
+## Implementation Notes (2026-06-03)
+
+- **Two findings were already clean**: the stray `.pyc` (already gitignored + untracked) and the "shipped empty dirs" (untracked scaffold, never in git). Verified rather than fixed; `rmdir` done locally for tidiness.
+- **Approach**: doc-trimming + inline-fallback phrasing (per the low-risk recommendation), not file-creation. Steps 4–5 of backend-endpoint and the with-hooks/container paths of frontend-component now instruct inline authoring instead of invoking absent generators/templates.
+- **Files**: skills/backend-endpoint/SKILL.md, skills/frontend-component/SKILL.md, skills/nav-stats/SKILL.md, CONTRIBUTING.md (new). Frontmatter is the only published surface touched.
 
 ## Technical Decisions
 
@@ -88,6 +94,6 @@ backend-test / frontend-test: `git rm` the empty examples/, functions/, template
 
 ## Done
 
-- [ ] All acceptance criteria checked
-- [ ] Tests pass in CI (once TASK-43 gate exists)
-- [ ] Committed + roadmap (TASK-42) status updated
+- [x] All acceptance criteria checked
+- [x] Tests pass (`make test` green — no code changed; doc-only WP)
+- [x] Committed + roadmap (TASK-42) status updated

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing to Navigator
+
+## Skill versioning convention
+
+Each skill carries its own `version:` in the `SKILL.md` frontmatter, bumped with
+[semver](https://semver.org/) **per skill** on any material change to that
+skill's behavior, steps, functions, or templates:
+
+- **patch** (x.y.**z**) — typo/wording fixes, no behavioral change
+- **minor** (x.**y**.0) — new steps, functions, templates, or options (backward compatible)
+- **major** (**x**.0.0) — removed/renamed functions or templates, or reworked workflow
+
+The skill `version:` is independent of the plugin version in
+`.claude-plugin/plugin.json` / `marketplace.json` (those track the release as a
+whole). Do **not** retro-version every skill on a plugin bump — only bump a
+skill when its own `SKILL.md` materially changes.
+
+> When in doubt, bump the skill minor on a feature add and major when you delete
+> or rename a referenced function/template (a consumer following the old SKILL.md
+> would break).

--- a/skills/backend-endpoint/SKILL.md
+++ b/skills/backend-endpoint/SKILL.md
@@ -2,7 +2,7 @@
 name: backend-endpoint
 description: Create REST/GraphQL API endpoint with validation, error handling, and tests. Auto-invoke when user says "add endpoint", "create API", "new route", or "add route".
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash
-version: 1.0.0
+version: 2.0.0
 ---
 
 # Backend API Endpoint Generator
@@ -214,36 +214,22 @@ export type CreateUserInput = z.infer<typeof createUserSchema>;
 
 ### Step 4: Generate Error Handling Middleware
 
-**Use predefined function**: `functions/error_handler_generator.py`
+**Write the error handler inline** (no generator script ships for this — author it directly to match the project's existing error-handling pattern).
 
-```bash
-python3 functions/error_handler_generator.py \
-  --framework "express" \
-  --template "templates/error-handler-template.ts" \
-  --output "src/middleware/errorHandler.ts"
-```
-
-**Error handler includes**:
+Write to `src/middleware/errorHandler.ts` an error handler that includes:
 - HTTP status code mapping
 - Error response formatting
 - Logging integration
 - Development vs production modes
 - Validation error handling
 
+Follow the framework's idiom (Express error middleware `(err, req, res, next)`; Next.js route-level `try/catch` returning `NextResponse.json`).
+
 ### Step 5: Generate Test File
 
-**Use predefined function**: `functions/test_generator.py`
+**Write the test inline**, using `templates/endpoint-test-template.spec.ts` as the reference shape (it ships as a reference template; no generator script drives it). Output to `tests/routes/users.test.ts`.
 
-```bash
-python3 functions/test_generator.py \
-  --endpoint "/api/users/:id" \
-  --method "GET" \
-  --framework "express" \
-  --template "templates/endpoint-test-template.spec.ts" \
-  --output "tests/routes/users.test.ts"
-```
-
-**Test template includes**:
+**The test should cover**:
 - Success case (200/201)
 - Validation errors (400)
 - Not found (404)
@@ -438,42 +424,8 @@ python3 functions/validation_generator.py \
 
 ---
 
-### 4. error_handler_generator.py
-
-Generates error handling middleware.
-
-**Usage**:
-```bash
-python3 functions/error_handler_generator.py \
-  --framework "express" \
-  --template "templates/error-handler-template.ts"
-```
-
-**Returns**: Error handler middleware code
-
----
-
-### 5. test_generator.py
-
-Generates endpoint integration tests.
-
-**Usage**:
-```bash
-python3 functions/test_generator.py \
-  --endpoint "/api/users/:id" \
-  --method "GET" \
-  --framework "express" \
-  --template "templates/endpoint-test-template.spec.ts"
-```
-
-**Generates tests for**:
-- Success responses
-- Validation errors
-- Authentication errors
-- Not found errors
-- Server errors
-
-**Returns**: Generated test code
+> **Error handling and tests are written inline** (Steps 4–5) — no
+> `error_handler_generator.py` / `test_generator.py` ship with this skill.
 
 ---
 
@@ -483,12 +435,13 @@ python3 functions/test_generator.py \
 
 Express.js route handler template.
 
-**Placeholders**:
+**Placeholders** (exactly those present in `templates/express-route-template.ts`):
 - `${ROUTE_PATH}` - API endpoint path
-- `${HTTP_METHOD}` - HTTP method (lowercase)
+- `${HTTP_METHOD}` - HTTP method (uppercase)
+- `${HTTP_METHOD_LOWER}` - HTTP method (lowercase, for the router call)
 - `${RESOURCE_NAME}` - Resource name (PascalCase)
-- `${VALIDATION_MIDDLEWARE}` - Validation middleware
-- `${AUTH_MIDDLEWARE}` - Authentication middleware
+- `${RESOURCE_NAME_LOWER}` - Resource name (lowercase)
+- `${MIDDLEWARE_BLOCK}` - Auth + validation middleware chain (built by `endpoint_generator.py` from the `--auth`/`--validation` flags)
 
 ### nextjs-route-template.ts (collection)
 
@@ -517,21 +470,14 @@ Next.js App Router Route Handler for a **single resource** endpoint with a dynam
 
 **Prefer Server Actions** over Route Handlers for **mutations from your own UI** (forms, buttons). Use Route Handlers for webhooks, third-party callers, and public REST endpoints. See `NEXTJS-PATTERNS.md` §F.
 
-### fastify-route-template.ts
-
-Fastify route handler template (alternative).
-
-### graphql-resolver-template.ts
-
-GraphQL resolver template (alternative).
-
-### validation-zod-template.ts
-
-Zod validation schema template.
+> Fastify, GraphQL, and Zod-schema generation are produced **inline** by the
+> model / `validation_generator.py` (Zod is built via its `ZOD_TYPE_MAP`, no
+> template file). Only the Express + Next.js route templates and the test
+> template below ship on disk.
 
 ### endpoint-test-template.spec.ts
 
-Integration test template with supertest.
+Integration test template with supertest (reference shape — written inline in Step 5).
 
 **Placeholders**:
 - `${ENDPOINT_PATH}` - Endpoint to test
@@ -546,7 +492,6 @@ See `examples/` directory for reference implementations:
 
 1. **users-get.ts** - GET endpoint with auth
 2. **users-post.ts** - POST endpoint with validation
-3. **graphql-resolver.ts** - GraphQL mutation example
 
 Each example includes:
 - Route/resolver implementation

--- a/skills/frontend-component/SKILL.md
+++ b/skills/frontend-component/SKILL.md
@@ -2,7 +2,7 @@
 name: frontend-component
 description: Create React/Vue component with TypeScript, tests, and styles. Auto-invoke when user says "create component", "add component", "new component", or "build component".
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash
-version: 1.0.0
+version: 2.0.0
 ---
 
 # Frontend Component Generator
@@ -161,14 +161,11 @@ interface UserProfileProps {
 Use template: templates/component-simple-template.tsx
 ```
 
-**Component with hooks**:
+**Component with hooks** / **Container component**:
 ```
-Use template: templates/component-with-hooks-template.tsx
-```
-
-**Container component**:
-```
-Use template: templates/component-container-template.tsx
+Start from templates/component-simple-template.tsx and add the hook
+declarations (useState/useEffect) or data-fetching logic inline — there is
+no separate with-hooks/container template file; the simple template is the base.
 ```
 
 **Next.js App Router variants** (use when `"next"` is in `package.json`):
@@ -485,22 +482,10 @@ Basic functional component template.
 - `${STYLE_IMPORT}` - CSS import statement
 - `${DESCRIPTION}` - Component description
 
-### component-with-hooks-template.tsx
-
-Component template with useState, useEffect examples.
-
-**Additional placeholders**:
-- `${HOOKS}` - Hook declarations
-- `${HANDLERS}` - Event handler functions
-
-### component-container-template.tsx
-
-Container component template with data fetching.
-
-**Additional placeholders**:
-- `${API_IMPORT}` - API function import
-- `${DATA_TYPE}` - Data type definition
-- `${FETCH_LOGIC}` - Data fetching implementation
+> Components needing hooks or data fetching start from
+> `component-simple-template.tsx` (above) and the model adds the
+> `useState`/`useEffect` declarations or fetch logic inline — no dedicated
+> with-hooks/container template ships.
 
 ### test-template.test.tsx
 
@@ -527,7 +512,6 @@ See `examples/` directory for reference implementations:
 
 1. **Button.tsx** - Simple component with variants
 2. **SearchBar.tsx** - Component with hooks (useState, useEffect)
-3. **UserProfile.tsx** - Container component with data fetching
 
 Each example includes:
 - Component implementation

--- a/skills/nav-stats/SKILL.md
+++ b/skills/nav-stats/SKILL.md
@@ -45,7 +45,7 @@ Execute the enhanced session statistics script:
 # Check if enhanced script exists
 if [ ! -f "scripts/session-stats.sh" ]; then
   echo "❌ Session stats script not found"
-  echo "This feature requires Navigator v3.5.0+"
+  echo "Reinstall or update Navigator to restore scripts/session-stats.sh"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Phase 1 wp8 of the audit remediation roadmap (TASK-42). Makes the two code-generator skills reference only files that actually ship, so the model is never directed to a nonexistent generator/template. Doc-only + frontmatter version bumps + removal of untracked scaffold dirs.

## Changes

- **`backend-endpoint/SKILL.md`** — Steps 4 (error handler) & 5 (tests) rewritten to inline authoring (`error_handler_generator.py` / `test_generator.py` never shipped); dropped Predefined Functions #4–#5; removed the `fastify` / `graphql-resolver` / `validation-zod` template doc blocks (no such files); **fixed the express-route placeholder list** to the six the template actually uses (added `${HTTP_METHOD_LOWER}` / `${RESOURCE_NAME_LOWER}` / `${MIDDLEWARE_BLOCK}`, dropped the `${VALIDATION_MIDDLEWARE}` / `${AUTH_MIDDLEWARE}` that aren't in it); dropped the `graphql-resolver.ts` example bullet; `version` 1.0.0 → 2.0.0.
- **`frontend-component/SKILL.md`** — with-hooks/container now start from `component-simple-template.tsx` inline (no dedicated template files exist); removed their template doc blocks + the `UserProfile.tsx` example bullet; `version` 1.0.0 → 2.0.0.
- **`nav-stats/SKILL.md`** — replaced the false `requires Navigator v3.5.0+` string with a version-neutral reinstall message (string only — the cwd-path check is wp3/TASK-49).
- **`CONTRIBUTING.md`** (new) — documents the per-skill semver convention (independent of the plugin version).
- Removed the **untracked** empty `functions/templates/examples` scaffold dirs from `backend-test` / `frontend-test` (git only tracked their SKILL.md — they never shipped).

## Two findings were already clean (verified, not fixed)

- Stray `.pyc`: `__pycache__/` is already gitignored (`.gitignore:64`) and `git ls-files` shows zero tracked pyc.
- "Shipped empty dirs": untracked scaffold, never in git.

## Verification

- A grep+stat script confirms **all 21** `functions/`/`templates/`/`examples/` references in both SKILL.md resolve on disk.
- Express placeholder list set-equals the template's actual placeholders.
- `grep v3.5.0 skills/nav-stats/SKILL.md` → empty.
- `make test` green; acceptance criteria in `.agent/tasks/TASK-50-skill-templates.md` all checked.