### PR TITLE
fix(graph): repair KG integrity + idempotent maintenance (TASK-47)

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -1,9 +1,9 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-06-03T12:08:43.170749Z",
+  "last_updated": "2026-06-03T10:41:10.574127+00:00",
   "stats": {
     "total_nodes": 133,
-    "total_edges": 886,
+    "total_edges": 706,
     "memory_count": 37
   },
   "nodes": {
@@ -1663,7 +1663,7 @@
         "type": "pattern",
         "summary": "Navigator user-facing flows map (v6.8.0): ~28 flows across 8 categories. Canonical path: start\u2192task-mode\u2192impl-skill\u2192simplify\u2192commit\u2192compact",
         "path": "memories/patterns/mem-026.md",
-        "confidence": 90.0,
+        "confidence": 0.9,
         "concepts": [
           "navigator-flows",
           "user-experience",
@@ -1914,24 +1914,6 @@
     },
     {
       "from": "SOP-navigator_plugin_release_workflow",
-      "to": "TASK-19",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-navigator_plugin_release_workflow",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-navigator_plugin_release_workflow",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-navigator_plugin_release_workflow",
       "to": "TASK-03",
       "type": "relates-to",
       "weight": 0.8
@@ -1969,12 +1951,6 @@
     {
       "from": "SOP-navigator_plugin_release_workflow",
       "to": "TASK-17",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-navigator_plugin_release_workflow",
-      "to": "TASK-18",
       "type": "relates-to",
       "weight": 1.0
     },
@@ -2034,12 +2010,6 @@
     },
     {
       "from": "SOP-navigator_plugin_release_workflow",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-navigator_plugin_release_workflow",
       "to": "TASK-29",
       "type": "relates-to",
       "weight": 1.0
@@ -2058,31 +2028,7 @@
     },
     {
       "from": "SOP-navigator_plugin_release_workflow",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.6000000000000001
-    },
-    {
-      "from": "SOP-navigator_plugin_release_workflow",
       "to": "TASK-10",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-navigator_plugin_release_workflow",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.6000000000000001
-    },
-    {
-      "from": "SOP-navigator_plugin_release_workflow",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-navigator_plugin_release_workflow",
-      "to": "TASK-18",
       "type": "relates-to",
       "weight": 1.0
     },
@@ -2148,24 +2094,6 @@
     },
     {
       "from": "SOP-plugin_release_workflow",
-      "to": "TASK-19",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-plugin_release_workflow",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-plugin_release_workflow",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-plugin_release_workflow",
       "to": "TASK-03",
       "type": "relates-to",
       "weight": 1.0
@@ -2203,12 +2131,6 @@
     {
       "from": "SOP-plugin_release_workflow",
       "to": "TASK-17",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-plugin_release_workflow",
-      "to": "TASK-18",
       "type": "relates-to",
       "weight": 1.0
     },
@@ -2262,12 +2184,6 @@
     },
     {
       "from": "SOP-plugin_release_workflow",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-plugin_release_workflow",
       "to": "TASK-29",
       "type": "relates-to",
       "weight": 1.0
@@ -2286,33 +2202,9 @@
     },
     {
       "from": "SOP-plugin_release_workflow",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-plugin_release_workflow",
       "to": "TASK-10",
       "type": "relates-to",
       "weight": 0.8
-    },
-    {
-      "from": "SOP-plugin_release_workflow",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-plugin_release_workflow",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-plugin_release_workflow",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 1.0
     },
     {
       "from": "SOP-multi_claude_troubleshooting",
@@ -2376,24 +2268,6 @@
     },
     {
       "from": "SOP-multi_claude_troubleshooting",
-      "to": "TASK-19",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-multi_claude_troubleshooting",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-multi_claude_troubleshooting",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-multi_claude_troubleshooting",
       "to": "TASK-03",
       "type": "relates-to",
       "weight": 1.0
@@ -2433,12 +2307,6 @@
       "to": "TASK-17",
       "type": "relates-to",
       "weight": 0.8
-    },
-    {
-      "from": "SOP-multi_claude_troubleshooting",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 1.0
     },
     {
       "from": "SOP-multi_claude_troubleshooting",
@@ -2496,12 +2364,6 @@
     },
     {
       "from": "SOP-multi_claude_troubleshooting",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-multi_claude_troubleshooting",
       "to": "TASK-29",
       "type": "relates-to",
       "weight": 1.0
@@ -2520,31 +2382,7 @@
     },
     {
       "from": "SOP-multi_claude_troubleshooting",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-multi_claude_troubleshooting",
       "to": "TASK-10",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-multi_claude_troubleshooting",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-multi_claude_troubleshooting",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-multi_claude_troubleshooting",
-      "to": "TASK-18",
       "type": "relates-to",
       "weight": 1.0
     },
@@ -2610,24 +2448,6 @@
     },
     {
       "from": "SOP-multi_claude_orchestration",
-      "to": "TASK-19",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-multi_claude_orchestration",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-multi_claude_orchestration",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-multi_claude_orchestration",
       "to": "TASK-03",
       "type": "relates-to",
       "weight": 1.0
@@ -2665,12 +2485,6 @@
     {
       "from": "SOP-multi_claude_orchestration",
       "to": "TASK-17",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-multi_claude_orchestration",
-      "to": "TASK-18",
       "type": "relates-to",
       "weight": 1.0
     },
@@ -2730,12 +2544,6 @@
     },
     {
       "from": "SOP-multi_claude_orchestration",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-multi_claude_orchestration",
       "to": "TASK-29",
       "type": "relates-to",
       "weight": 1.0
@@ -2754,31 +2562,7 @@
     },
     {
       "from": "SOP-multi_claude_orchestration",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-multi_claude_orchestration",
       "to": "TASK-10",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-multi_claude_orchestration",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-multi_claude_orchestration",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-multi_claude_orchestration",
-      "to": "TASK-18",
       "type": "relates-to",
       "weight": 1.0
     },
@@ -2844,24 +2628,6 @@
     },
     {
       "from": "SOP-version_management",
-      "to": "TASK-19",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-version_management",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-version_management",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.6000000000000001
-    },
-    {
-      "from": "SOP-version_management",
       "to": "TASK-03",
       "type": "relates-to",
       "weight": 0.8
@@ -2899,12 +2665,6 @@
     {
       "from": "SOP-version_management",
       "to": "TASK-17",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-version_management",
-      "to": "TASK-18",
       "type": "relates-to",
       "weight": 0.8
     },
@@ -2964,12 +2724,6 @@
     },
     {
       "from": "SOP-version_management",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-version_management",
       "to": "TASK-29",
       "type": "relates-to",
       "weight": 1.0
@@ -2988,31 +2742,7 @@
     },
     {
       "from": "SOP-version_management",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.6000000000000001
-    },
-    {
-      "from": "SOP-version_management",
       "to": "TASK-10",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-version_management",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.6000000000000001
-    },
-    {
-      "from": "SOP-version_management",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-version_management",
-      "to": "TASK-18",
       "type": "relates-to",
       "weight": 1.0
     },
@@ -3078,24 +2808,6 @@
     },
     {
       "from": "SOP-complete_release_workflow",
-      "to": "TASK-19",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-complete_release_workflow",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-complete_release_workflow",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-complete_release_workflow",
       "to": "TASK-03",
       "type": "relates-to",
       "weight": 1.0
@@ -3135,12 +2847,6 @@
       "to": "TASK-17",
       "type": "relates-to",
       "weight": 1.0
-    },
-    {
-      "from": "SOP-complete_release_workflow",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
     },
     {
       "from": "SOP-complete_release_workflow",
@@ -3198,12 +2904,6 @@
     },
     {
       "from": "SOP-complete_release_workflow",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-complete_release_workflow",
       "to": "TASK-29",
       "type": "relates-to",
       "weight": 1.0
@@ -3222,31 +2922,7 @@
     },
     {
       "from": "SOP-complete_release_workflow",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.6000000000000001
-    },
-    {
-      "from": "SOP-complete_release_workflow",
       "to": "TASK-10",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-complete_release_workflow",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-complete_release_workflow",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-complete_release_workflow",
-      "to": "TASK-18",
       "type": "relates-to",
       "weight": 1.0
     },
@@ -3312,24 +2988,6 @@
     },
     {
       "from": "SOP-autonomous_completion",
-      "to": "TASK-19",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-autonomous_completion",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-autonomous_completion",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.6000000000000001
-    },
-    {
-      "from": "SOP-autonomous_completion",
       "to": "TASK-03",
       "type": "relates-to",
       "weight": 1.0
@@ -3369,12 +3027,6 @@
       "to": "TASK-17",
       "type": "relates-to",
       "weight": 0.8
-    },
-    {
-      "from": "SOP-autonomous_completion",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 1.0
     },
     {
       "from": "SOP-autonomous_completion",
@@ -3432,12 +3084,6 @@
     },
     {
       "from": "SOP-autonomous_completion",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.6000000000000001
-    },
-    {
-      "from": "SOP-autonomous_completion",
       "to": "TASK-29",
       "type": "relates-to",
       "weight": 1.0
@@ -3456,31 +3102,7 @@
     },
     {
       "from": "SOP-autonomous_completion",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-autonomous_completion",
       "to": "TASK-10",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-autonomous_completion",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.6000000000000001
-    },
-    {
-      "from": "SOP-autonomous_completion",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-autonomous_completion",
-      "to": "TASK-18",
       "type": "relates-to",
       "weight": 1.0
     },
@@ -3517,12 +3139,6 @@
     {
       "from": "SOP-test_failures",
       "to": "TASK-13",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-test_failures",
-      "to": "TASK-19",
       "type": "relates-to",
       "weight": 0.8
     },
@@ -3611,12 +3227,6 @@
       "weight": 0.6000000000000001
     },
     {
-      "from": "SOP-test_failures",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.4
-    },
-    {
       "from": "SOP-grafana_dashboard_empty_data",
       "to": "TASK-32",
       "type": "relates-to",
@@ -3678,24 +3288,6 @@
     },
     {
       "from": "SOP-grafana_dashboard_empty_data",
-      "to": "TASK-19",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-grafana_dashboard_empty_data",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.6000000000000001
-    },
-    {
-      "from": "SOP-grafana_dashboard_empty_data",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-grafana_dashboard_empty_data",
       "to": "TASK-03",
       "type": "relates-to",
       "weight": 0.8
@@ -3733,12 +3325,6 @@
     {
       "from": "SOP-grafana_dashboard_empty_data",
       "to": "TASK-17",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-grafana_dashboard_empty_data",
-      "to": "TASK-18",
       "type": "relates-to",
       "weight": 0.8
     },
@@ -3798,12 +3384,6 @@
     },
     {
       "from": "SOP-grafana_dashboard_empty_data",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.6000000000000001
-    },
-    {
-      "from": "SOP-grafana_dashboard_empty_data",
       "to": "TASK-29",
       "type": "relates-to",
       "weight": 1.0
@@ -3822,33 +3402,9 @@
     },
     {
       "from": "SOP-grafana_dashboard_empty_data",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.6000000000000001
-    },
-    {
-      "from": "SOP-grafana_dashboard_empty_data",
       "to": "TASK-10",
       "type": "relates-to",
       "weight": 1.0
-    },
-    {
-      "from": "SOP-grafana_dashboard_empty_data",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.4
-    },
-    {
-      "from": "SOP-grafana_dashboard_empty_data",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-grafana_dashboard_empty_data",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
     },
     {
       "from": "SOP-opentelemetry_setup",
@@ -3912,24 +3468,6 @@
     },
     {
       "from": "SOP-opentelemetry_setup",
-      "to": "TASK-19",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-opentelemetry_setup",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-opentelemetry_setup",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-opentelemetry_setup",
       "to": "TASK-03",
       "type": "relates-to",
       "weight": 1.0
@@ -3963,12 +3501,6 @@
       "to": "TASK-17",
       "type": "relates-to",
       "weight": 0.8
-    },
-    {
-      "from": "SOP-opentelemetry_setup",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 1.0
     },
     {
       "from": "SOP-opentelemetry_setup",
@@ -4014,12 +3546,6 @@
     },
     {
       "from": "SOP-opentelemetry_setup",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-opentelemetry_setup",
       "to": "TASK-29",
       "type": "relates-to",
       "weight": 0.8
@@ -4038,33 +3564,9 @@
     },
     {
       "from": "SOP-opentelemetry_setup",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.6000000000000001
-    },
-    {
-      "from": "SOP-opentelemetry_setup",
       "to": "TASK-10",
       "type": "relates-to",
       "weight": 0.6000000000000001
-    },
-    {
-      "from": "SOP-opentelemetry_setup",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.6000000000000001
-    },
-    {
-      "from": "SOP-opentelemetry_setup",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.6000000000000001
-    },
-    {
-      "from": "SOP-opentelemetry_setup",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
     },
     {
       "from": "SOP-visual_regression_setup",
@@ -4128,24 +3630,6 @@
     },
     {
       "from": "SOP-visual_regression_setup",
-      "to": "TASK-19",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "SOP-visual_regression_setup",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-visual_regression_setup",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-visual_regression_setup",
       "to": "TASK-03",
       "type": "relates-to",
       "weight": 0.8
@@ -4185,12 +3669,6 @@
       "to": "TASK-17",
       "type": "relates-to",
       "weight": 1.0
-    },
-    {
-      "from": "SOP-visual_regression_setup",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.6000000000000001
     },
     {
       "from": "SOP-visual_regression_setup",
@@ -4242,12 +3720,6 @@
     },
     {
       "from": "SOP-visual_regression_setup",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-visual_regression_setup",
       "to": "TASK-29",
       "type": "relates-to",
       "weight": 1.0
@@ -4266,33 +3738,9 @@
     },
     {
       "from": "SOP-visual_regression_setup",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-visual_regression_setup",
       "to": "TASK-10",
       "type": "relates-to",
       "weight": 1.0
-    },
-    {
-      "from": "SOP-visual_regression_setup",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.6000000000000001
-    },
-    {
-      "from": "SOP-visual_regression_setup",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.6000000000000001
-    },
-    {
-      "from": "SOP-visual_regression_setup",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
     },
     {
       "from": "SOP-plugin_release",
@@ -4350,24 +3798,6 @@
     },
     {
       "from": "SOP-plugin_release",
-      "to": "TASK-19",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "SOP-plugin_release",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.6000000000000001
-    },
-    {
-      "from": "SOP-plugin_release",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.4
-    },
-    {
-      "from": "SOP-plugin_release",
       "to": "TASK-03",
       "type": "relates-to",
       "weight": 0.6000000000000001
@@ -4401,12 +3831,6 @@
       "to": "TASK-17",
       "type": "relates-to",
       "weight": 0.6000000000000001
-    },
-    {
-      "from": "SOP-plugin_release",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.4
     },
     {
       "from": "SOP-plugin_release",
@@ -4464,12 +3888,6 @@
     },
     {
       "from": "SOP-plugin_release",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.6000000000000001
-    },
-    {
-      "from": "SOP-plugin_release",
       "to": "TASK-29",
       "type": "relates-to",
       "weight": 0.8
@@ -4488,31 +3906,7 @@
     },
     {
       "from": "SOP-plugin_release",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.4
-    },
-    {
-      "from": "SOP-plugin_release",
       "to": "TASK-10",
-      "type": "relates-to",
-      "weight": 0.6000000000000001
-    },
-    {
-      "from": "SOP-plugin_release",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.4
-    },
-    {
-      "from": "SOP-plugin_release",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.4
-    },
-    {
-      "from": "SOP-plugin_release",
-      "to": "TASK-18",
       "type": "relates-to",
       "weight": 0.6000000000000001
     },
@@ -4578,24 +3972,6 @@
     },
     {
       "from": "plugin-patterns",
-      "to": "TASK-19",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "plugin-patterns",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "plugin-patterns",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "plugin-patterns",
       "to": "TASK-03",
       "type": "relates-to",
       "weight": 1.0
@@ -4633,12 +4009,6 @@
     {
       "from": "plugin-patterns",
       "to": "TASK-17",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "plugin-patterns",
-      "to": "TASK-18",
       "type": "relates-to",
       "weight": 1.0
     },
@@ -4698,12 +4068,6 @@
     },
     {
       "from": "plugin-patterns",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "plugin-patterns",
       "to": "TASK-29",
       "type": "relates-to",
       "weight": 1.0
@@ -4722,31 +4086,7 @@
     },
     {
       "from": "plugin-patterns",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "plugin-patterns",
       "to": "TASK-10",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "plugin-patterns",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "plugin-patterns",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "plugin-patterns",
-      "to": "TASK-18",
       "type": "relates-to",
       "weight": 1.0
     },
@@ -4812,24 +4152,6 @@
     },
     {
       "from": "project-architecture",
-      "to": "TASK-19",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "project-architecture",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "project-architecture",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "project-architecture",
       "to": "TASK-03",
       "type": "relates-to",
       "weight": 1.0
@@ -4867,12 +4189,6 @@
     {
       "from": "project-architecture",
       "to": "TASK-17",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "project-architecture",
-      "to": "TASK-18",
       "type": "relates-to",
       "weight": 1.0
     },
@@ -4932,12 +4248,6 @@
     },
     {
       "from": "project-architecture",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "project-architecture",
       "to": "TASK-29",
       "type": "relates-to",
       "weight": 1.0
@@ -4956,31 +4266,7 @@
     },
     {
       "from": "project-architecture",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 0.8
-    },
-    {
-      "from": "project-architecture",
       "to": "TASK-10",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "project-architecture",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "project-architecture",
-      "to": "TASK-18",
-      "type": "relates-to",
-      "weight": 1.0
-    },
-    {
-      "from": "project-architecture",
-      "to": "TASK-18",
       "type": "relates-to",
       "weight": 1.0
     },
@@ -5346,27 +4632,7 @@
     },
     {
       "from": "TASK-19",
-      "to": "database",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-19",
-      "to": "deployment",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-19",
-      "to": "api",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-19",
       "to": "backend",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-19",
-      "to": "code quality",
       "type": "implements"
     },
     {
@@ -5381,37 +4647,7 @@
     },
     {
       "from": "TASK-19",
-      "to": "testing",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-19",
-      "to": "markers",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-19",
       "to": "authentication",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-19",
-      "to": "context",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-19",
-      "to": "workflow",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-19",
-      "to": "skills",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-19",
-      "to": "session",
       "type": "implements"
     },
     {
@@ -5421,32 +4657,12 @@
     },
     {
       "from": "TASK-18",
-      "to": "session",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "testing",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
       "to": "markers",
       "type": "implements"
     },
     {
       "from": "TASK-18",
-      "to": "context",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
       "to": "workflow",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "skills",
       "type": "implements"
     },
     {
@@ -5457,26 +4673,6 @@
     {
       "from": "TASK-18",
       "to": "deployment",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "testing",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "context",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "skills",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "session",
       "type": "implements"
     },
     {
@@ -5720,31 +4916,6 @@
       "type": "implements"
     },
     {
-      "from": "TASK-18",
-      "to": "markers",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "context",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "workflow",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "skills",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "session",
-      "type": "implements"
-    },
-    {
       "from": "TASK-06",
       "to": "api",
       "type": "implements"
@@ -6100,31 +5271,6 @@
       "type": "implements"
     },
     {
-      "from": "TASK-18",
-      "to": "testing",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "context",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "workflow",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "skills",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "session",
-      "type": "implements"
-    },
-    {
       "from": "TASK-29",
       "to": "database",
       "type": "implements"
@@ -6266,27 +5412,7 @@
     },
     {
       "from": "TASK-18",
-      "to": "testing",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "context",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
       "to": "frontend",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "skills",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "session",
       "type": "implements"
     },
     {
@@ -6341,105 +5467,10 @@
     },
     {
       "from": "TASK-18",
-      "to": "session",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "testing",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "markers",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "context",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "workflow",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "knowledge",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
       "to": "database",
       "type": "implements"
     },
     {
-      "from": "TASK-18",
-      "to": "session",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "testing",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "markers",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "context",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "skills",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "knowledge",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "api",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "testing",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "markers",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "context",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "workflow",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "skills",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-18",
-      "to": "session",
-      "type": "implements"
-    },
-    {
       "from": "TASK-38",
       "to": "skills",
       "type": "implements"
@@ -6447,11 +5478,6 @@
     {
       "from": "TASK-38",
       "to": "knowledge",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-38",
-      "to": "tom",
       "type": "implements"
     },
     {
@@ -6490,16 +5516,6 @@
       "type": "implements"
     },
     {
-      "from": "mem-032",
-      "to": "TASK-39",
-      "type": "learned-from"
-    },
-    {
-      "from": "mem-033",
-      "to": "TASK-39",
-      "type": "learned-from"
-    },
-    {
       "from": "TASK-41",
       "to": "deployment",
       "type": "implements"
@@ -6507,11 +5523,6 @@
     {
       "from": "TASK-41",
       "to": "api",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-41",
-      "to": "tom",
       "type": "implements"
     },
     {
@@ -6571,11 +5582,6 @@
     },
     {
       "from": "mem-037",
-      "to": "RELEASE-v6.15.3",
-      "type": "learned-from"
-    },
-    {
-      "from": "mem-037",
       "to": "mem-027",
       "type": "relates-to"
     },
@@ -6611,11 +5617,6 @@
     },
     {
       "from": "TASK-40",
-      "to": "tom",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-40",
       "to": "skills",
       "type": "implements"
     },
@@ -6647,11 +5648,6 @@
     {
       "from": "TASK-44",
       "to": "skills",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-44",
-      "to": "tom",
       "type": "implements"
     },
     {
@@ -6711,22 +5707,12 @@
     },
     {
       "from": "TASK-50",
-      "to": "tom",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-50",
       "to": "api",
       "type": "implements"
     },
     {
       "from": "TASK-45",
       "to": "markers",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-45",
-      "to": "tom",
       "type": "implements"
     },
     {
@@ -6767,11 +5753,6 @@
     {
       "from": "TASK-46",
       "to": "api",
-      "type": "implements"
-    },
-    {
-      "from": "TASK-46",
-      "to": "tom",
       "type": "implements"
     },
     {

--- a/skills/nav-graph/SKILL.md
+++ b/skills/nav-graph/SKILL.md
@@ -410,6 +410,12 @@ In `.agent/.nav-config.json`:
 }
 ```
 
+**Note**: `confidence_decay_rate` and `staleness_threshold_days` are consumed
+only by the manual `graph_maintenance` commands (`--action decay` /
+`--action stale`). They are **not** applied automatically on session start —
+decaying a git-tracked file every session would create constant churn. Run
+decay/staleness manually when curating the graph.
+
 ---
 
 ## Graph Maintenance
@@ -423,16 +429,40 @@ Output:
 ```
 Knowledge Graph Health Check
 ========================================
-Total Nodes: 94
-Total Edges: 819
-Memories: 2 (2 high confidence)
+Total Nodes: 133
+Total Edges: 706
+Memories: 37 (37 high confidence)
+Tasks: 38
+Concepts: 16
+Orphan Nodes: 0
+Duplicate Edges: 0
+Dangling Edges: 0
+Confidence Out-of-Range: 0
+
 Health Score: 100/100
 
-No issues detected!
+No integrity issues detected!
+
+Advisory (not scored):
+  - 8 potential memory conflicts (heuristic, advisory)
+  - 3 stale memories (not validated in 90+ days)
+```
+
+`Duplicate Edges`, `Dangling Edges`, and `Confidence Out-of-Range` are the
+integrity gate — all three should read `0` on a healthy graph. If they don't,
+run `--action repair` (below).
+
+### Repair Integrity Defects
+Idempotently dedupe `(from, to, type)` edge rows, drop edges that reference a
+missing node id, and normalize out-of-range memory confidences (a value like
+`90.0` is treated as `90%` → `0.9`). Safe to re-run:
+```bash
+python3 skills/nav-graph/functions/graph_maintenance.py --action repair
 ```
 
 ### Conflict Detection
-Find memories that may contradict each other:
+Find memories that may contradict each other. **Advisory only** — a
+high-false-positive keyword heuristic that does **not** affect the health score:
 ```bash
 python3 skills/nav-graph/functions/graph_maintenance.py --action conflicts
 ```
@@ -453,10 +483,13 @@ python3 skills/nav-graph/functions/graph_maintenance.py --action prune --thresho
 python3 skills/nav-graph/functions/graph_maintenance.py --action prune --threshold 0.3 --execute
 ```
 
-### Apply Decay
-Reduce confidence of stale memories:
+### Apply Decay (experimental, manual-only)
+Reduce confidence based on time since each memory's last decay. **Idempotent** —
+running it twice on the same day is a no-op (each memory tracks `last_decayed`).
+The rate defaults to `knowledge_graph.confidence_decay_rate` when `--decay-rate`
+is omitted. This is **not** wired to any hook; run it manually when curating:
 ```bash
-python3 skills/nav-graph/functions/graph_maintenance.py --action decay --decay-rate 0.01
+python3 skills/nav-graph/functions/graph_maintenance.py --action decay
 ```
 
 ---

--- a/skills/nav-graph/functions/graph_builder.py
+++ b/skills/nav-graph/functions/graph_builder.py
@@ -13,9 +13,12 @@ import json
 import re
 import sys
 import argparse
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
+
+sys.path.insert(0, str(Path(__file__).parent))
+from graph_manager import add_edge
 
 
 def extract_concepts_from_text(text: str) -> list:
@@ -391,7 +394,7 @@ def build_graph(agent_dir: str) -> dict:
     # Build graph structure
     graph = {
         "version": "1.0.0",
-        "last_updated": datetime.now().isoformat() + "Z",
+        "last_updated": datetime.now(timezone.utc).isoformat(),
         "stats": {},
         "nodes": {
             "tasks": {t['id']: t for t in tasks},
@@ -402,9 +405,21 @@ def build_graph(agent_dir: str) -> dict:
             "memories": {},
             "files": {}
         },
-        "edges": infer_edges(tasks, sops, system_docs),
+        "edges": [],
         "concept_index": {}
     }
+
+    # Route inferred edges through add_edge so duplicate (from,to,type) rows are
+    # collapsed, and drop any edge whose endpoints are not real node ids
+    # (referential integrity — prevents the dangling 'tom'/TASK-* edges the
+    # audit found from being reintroduced on every rebuild).
+    node_ids = set()
+    for bucket in graph["nodes"].values():
+        node_ids.update(bucket.keys())
+    for edge in infer_edges(tasks, sops, system_docs):
+        if edge["from"] in node_ids and edge["to"] in node_ids:
+            graph = add_edge(graph, edge["from"], edge["to"], edge["type"],
+                             edge.get("weight", 1.0))
 
     # Build concept index
     for node_type, nodes in graph["nodes"].items():

--- a/skills/nav-graph/functions/graph_maintenance.py
+++ b/skills/nav-graph/functions/graph_maintenance.py
@@ -8,12 +8,147 @@ Maintains knowledge graph health over time.
 import json
 import sys
 import argparse
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional
 
 sys.path.insert(0, str(Path(__file__).parent))
 from graph_manager import load_graph, save_graph
+
+DEFAULT_DECAY_RATE = 0.01
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Integrity helpers (wp6 / TASK-47)
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _all_node_ids(graph: dict) -> set:
+    """Union of every node id across all node buckets (concepts included).
+
+    A concept node is keyed by its canonical name, so an 'implements' edge that
+    points task -> concept is valid only when that concept name is a node id.
+    """
+    ids = set()
+    for nodes in graph.get('nodes', {}).values():
+        ids.update(nodes.keys())
+    return ids
+
+
+def _edge_key(edge: dict) -> tuple:
+    return (edge.get('from'), edge.get('to'), edge.get('type'))
+
+
+def find_duplicate_edges(graph: dict) -> int:
+    """Count edge rows that repeat an earlier (from, to, type) tuple."""
+    seen = set()
+    dupes = 0
+    for edge in graph.get('edges', []):
+        key = _edge_key(edge)
+        if key in seen:
+            dupes += 1
+        else:
+            seen.add(key)
+    return dupes
+
+
+def find_dangling_edges(graph: dict) -> list:
+    """Return edges whose `from` or `to` is not a known node id."""
+    node_ids = _all_node_ids(graph)
+    return [
+        e for e in graph.get('edges', [])
+        if e.get('from') not in node_ids or e.get('to') not in node_ids
+    ]
+
+
+def find_out_of_range_confidence(graph: dict) -> list:
+    """Return (id, confidence) for memories whose confidence is outside [0,1]."""
+    out = []
+    for mem_id, mem in graph.get('nodes', {}).get('memories', {}).items():
+        c = mem.get('confidence')
+        if isinstance(c, (int, float)) and (c < 0.0 or c > 1.0):
+            out.append((mem_id, c))
+    return out
+
+
+def _normalize_confidence_value(c: float) -> float:
+    """Repair an out-of-range confidence in EXISTING data.
+
+    Values in (1, 100] are treated as mis-stored percentages (mem-026 shipped
+    as 90.0, i.e. 90% -> 0.9); anything else out of range is clamped to [0,1].
+    """
+    if c < 0.0:
+        return 0.0
+    if c > 1.0:
+        scaled = round(c / 100.0, 2)
+        return scaled if scaled <= 1.0 else 1.0
+    return c
+
+
+def repair_graph(graph: dict) -> dict:
+    """Idempotently repair graph integrity defects in place.
+
+    - drop duplicate (from, to, type) edge rows (keep first occurrence)
+    - drop edges referencing an absent node id (dangling)
+    - normalize out-of-range memory confidences
+
+    Returns a summary dict. Running it a second time is a no-op.
+    """
+    edges = graph.get('edges', [])
+    before = len(edges)
+    node_ids = _all_node_ids(graph)
+
+    seen = set()
+    cleaned = []
+    dup_removed = 0
+    dangling_removed = 0
+    for edge in edges:
+        if edge.get('from') not in node_ids or edge.get('to') not in node_ids:
+            dangling_removed += 1
+            continue
+        key = _edge_key(edge)
+        if key in seen:
+            dup_removed += 1
+            continue
+        seen.add(key)
+        cleaned.append(edge)
+    graph['edges'] = cleaned
+
+    conf_fixed = 0
+    for mem in graph.get('nodes', {}).get('memories', {}).values():
+        c = mem.get('confidence')
+        if isinstance(c, (int, float)) and (c < 0.0 or c > 1.0):
+            mem['confidence'] = _normalize_confidence_value(c)
+            conf_fixed += 1
+
+    return {
+        'edges_before': before,
+        'edges_after': len(cleaned),
+        'duplicates_removed': dup_removed,
+        'dangling_removed': dangling_removed,
+        'confidences_normalized': conf_fixed,
+    }
+
+
+def _read_decay_rate(config_path: str) -> float:
+    """Read knowledge_graph.confidence_decay_rate from config (default 0.01)."""
+    try:
+        with open(config_path) as f:
+            cfg = json.load(f)
+        rate = cfg.get('knowledge_graph', {}).get('confidence_decay_rate')
+        return float(rate) if rate is not None else DEFAULT_DECAY_RATE
+    except (FileNotFoundError, json.JSONDecodeError, TypeError, ValueError):
+        return DEFAULT_DECAY_RATE
+
+
+def _read_staleness_days(config_path: str) -> int:
+    """Read knowledge_graph.staleness_threshold_days from config (default 90)."""
+    try:
+        with open(config_path) as f:
+            cfg = json.load(f)
+        days = cfg.get('knowledge_graph', {}).get('staleness_threshold_days')
+        return int(days) if days is not None else 90
+    except (FileNotFoundError, json.JSONDecodeError, TypeError, ValueError):
+        return 90
 
 
 def detect_conflicts(graph: dict) -> list:
@@ -121,26 +256,44 @@ def find_low_confidence(graph: dict, threshold: float = 0.3) -> list:
     return sorted(low_conf, key=lambda x: x['confidence'])
 
 
-def apply_decay(graph: dict, decay_rate: float = 0.01) -> dict:
-    """Apply confidence decay to all memories based on time since validation."""
-    now = datetime.now()
+def apply_decay(graph: dict, decay_rate: Optional[float] = None,
+                config_path: str = '.agent/.nav-config.json',
+                today: Optional[object] = None) -> dict:
+    """Idempotently decay memory confidence by time since the last decay.
 
-    for mem_id, mem_data in graph['nodes'].get('memories', {}).items():
-        last_validated = mem_data.get('last_validated')
-        if not last_validated:
+    EXPERIMENTAL / manual-only: this is NOT wired to any hook. Decaying on every
+    session start would mutate a git-tracked file each session (fights
+    knowledge_graph.git_tracked=true), so decay runs only via an explicit
+    `--action decay` invocation.
+
+    Idempotency: decay accrues from each memory's `last_decayed` anchor (falling
+    back to `last_validated`), and the anchor is advanced to `today` after each
+    run. Running twice on the same calendar day is therefore a no-op. The rate
+    defaults to knowledge_graph.confidence_decay_rate from config.
+    """
+    if decay_rate is None:
+        decay_rate = _read_decay_rate(config_path)
+    if today is None:
+        today = datetime.now(timezone.utc).date()
+    today_str = today.isoformat()
+
+    for mem_data in graph['nodes'].get('memories', {}).values():
+        anchor = mem_data.get('last_decayed') or mem_data.get('last_validated')
+        if not anchor:
+            continue
+        try:
+            anchor_date = datetime.strptime(anchor, '%Y-%m-%d').date()
+        except (ValueError, TypeError):
             continue
 
-        try:
-            validated_date = datetime.strptime(last_validated, '%Y-%m-%d')
-            days_since = (now - validated_date).days
-            weeks_since = days_since / 7
+        days_since = (today - anchor_date).days
+        mem_data['last_decayed'] = today_str
+        if days_since <= 0:
+            continue  # already decayed today (or future-dated) — no-op
 
-            # Apply decay: 1% per week
-            current_conf = mem_data.get('confidence', 0.8)
-            new_conf = max(0.0, current_conf - (decay_rate * weeks_since))
-            mem_data['confidence'] = round(new_conf, 2)
-        except ValueError:
-            pass
+        weeks_since = days_since / 7
+        current_conf = mem_data.get('confidence', 0.8)
+        mem_data['confidence'] = round(max(0.0, current_conf - (decay_rate * weeks_since)), 2)
 
     return graph
 
@@ -162,10 +315,16 @@ def prune_memories(graph: dict, threshold: float = 0.3, dry_run: bool = True) ->
         for mem_id in to_remove:
             del graph['nodes']['memories'][mem_id]
 
-            # Remove from concept index
-            for concept in graph.get('concept_index', {}).values():
-                if mem_id in concept:
-                    concept.remove(mem_id)
+            # Remove from concept index, dropping now-empty concept keys
+            # (mirror remove_node — leftover empty keys are graph cruft).
+            empty_concepts = []
+            for concept, members in graph.get('concept_index', {}).items():
+                if mem_id in members:
+                    members.remove(mem_id)
+                    if not members:
+                        empty_concepts.append(concept)
+            for concept in empty_concepts:
+                del graph['concept_index'][concept]
 
             # Remove edges
             graph['edges'] = [e for e in graph['edges']
@@ -211,22 +370,39 @@ def health_check(graph: dict) -> dict:
     orphans = all_node_ids - indexed_nodes
     stats['orphan_nodes'] = len(orphans)
 
-    # Issues
+    # Integrity defects — the wp6 health gate (these must read 0 post-repair).
+    dup_edges = find_duplicate_edges(graph)
+    dangling = find_dangling_edges(graph)
+    oor_conf = find_out_of_range_confidence(graph)
+    stats['duplicate_edges'] = dup_edges
+    stats['dangling_edges'] = len(dangling)
+    stats['confidence_out_of_range'] = len(oor_conf)
+
+    # Issues (score-affecting): integrity defects + low-confidence volume.
     issues = []
+    if dup_edges:
+        issues.append(f'{dup_edges} duplicate edges')
+    if dangling:
+        issues.append(f'{len(dangling)} dangling edges (reference missing nodes)')
+    if oor_conf:
+        issues.append(f'{len(oor_conf)} memories with confidence outside [0,1]')
     if low_conf > 0:
         issues.append(f'{low_conf} memories below 0.3 confidence (prune candidates)')
     if len(orphans) > 10:
         issues.append(f'{len(orphans)} nodes not indexed by any concept')
 
+    # Advisory (NOT score-affecting): the conflict heuristic is high-false-
+    # positive and staleness is expected on an actively-curated graph.
+    advisory = []
     conflicts = detect_conflicts(graph)
     if conflicts:
-        issues.append(f'{len(conflicts)} potential memory conflicts detected')
-
+        advisory.append(f'{len(conflicts)} potential memory conflicts (heuristic, advisory)')
     stale = find_stale_memories(graph)
     if stale:
-        issues.append(f'{len(stale)} stale memories (not validated in 90+ days)')
+        advisory.append(f'{len(stale)} stale memories (not validated in 90+ days)')
 
     stats['issues'] = issues
+    stats['advisory'] = advisory
     stats['health_score'] = max(0, 100 - len(issues) * 15 - low_conf * 5)
 
     return stats
@@ -236,16 +412,16 @@ def main():
     parser = argparse.ArgumentParser(description='Knowledge graph maintenance')
     parser.add_argument('--action', required=True,
                        choices=['health', 'conflicts', 'stale', 'low-confidence',
-                               'decay', 'prune'],
+                               'decay', 'prune', 'repair'],
                        help='Action to perform')
     parser.add_argument('--graph-path', default='.agent/knowledge/graph.json',
                        help='Path to knowledge graph')
     parser.add_argument('--threshold', type=float, default=0.3,
                        help='Confidence threshold for pruning')
-    parser.add_argument('--stale-days', type=int, default=90,
-                       help='Days until memory considered stale')
-    parser.add_argument('--decay-rate', type=float, default=0.01,
-                       help='Decay rate per week')
+    parser.add_argument('--stale-days', type=int, default=None,
+                       help='Days until memory considered stale (default: knowledge_graph.staleness_threshold_days)')
+    parser.add_argument('--decay-rate', type=float, default=None,
+                       help='Decay rate per week (default: knowledge_graph.confidence_decay_rate)')
     parser.add_argument('--dry-run', action='store_true', default=True,
                        help='Show what would be pruned without removing')
     parser.add_argument('--execute', action='store_true',
@@ -264,13 +440,33 @@ def main():
         print(f"Tasks: {result['task_count']}")
         print(f"Concepts: {result['concept_count']}")
         print(f"Orphan Nodes: {result['orphan_nodes']}")
+        print(f"Duplicate Edges: {result['duplicate_edges']}")
+        print(f"Dangling Edges: {result['dangling_edges']}")
+        print(f"Confidence Out-of-Range: {result['confidence_out_of_range']}")
         print(f"\nHealth Score: {result['health_score']}/100")
         if result['issues']:
             print("\nIssues:")
             for issue in result['issues']:
                 print(f"  - {issue}")
         else:
-            print("\nNo issues detected!")
+            print("\nNo integrity issues detected!")
+        if result.get('advisory'):
+            print("\nAdvisory (not scored):")
+            for note in result['advisory']:
+                print(f"  - {note}")
+
+    elif args.action == 'repair':
+        summary = repair_graph(graph)
+        if save_graph(args.graph_path, graph):
+            print("Knowledge Graph Repair")
+            print("=" * 40)
+            print(f"Edges: {summary['edges_before']} -> {summary['edges_after']}")
+            print(f"  Duplicates removed: {summary['duplicates_removed']}")
+            print(f"  Dangling removed:   {summary['dangling_removed']}")
+            print(f"Confidences normalized: {summary['confidences_normalized']}")
+        else:
+            print("Failed to save graph", file=sys.stderr)
+            sys.exit(1)
 
     elif args.action == 'conflicts':
         conflicts = detect_conflicts(graph)
@@ -285,7 +481,9 @@ def main():
             print("No conflicts detected!")
 
     elif args.action == 'stale':
-        stale = find_stale_memories(graph, args.stale_days)
+        stale_days = (args.stale_days if args.stale_days is not None
+                      else _read_staleness_days('.agent/.nav-config.json'))
+        stale = find_stale_memories(graph, stale_days)
         if stale:
             print(f"Found {len(stale)} stale memories:\n")
             for s in stale:
@@ -305,9 +503,11 @@ def main():
             print(f"No memories below {args.threshold} confidence!")
 
     elif args.action == 'decay':
-        graph = apply_decay(graph, args.decay_rate)
+        effective_rate = (args.decay_rate if args.decay_rate is not None
+                          else _read_decay_rate('.agent/.nav-config.json'))
+        graph = apply_decay(graph, effective_rate)
         if save_graph(args.graph_path, graph):
-            print(f"Applied decay (rate: {args.decay_rate}/week) to all memories")
+            print(f"Applied decay (rate: {effective_rate}/week, idempotent per day)")
         else:
             print("Failed to save graph", file=sys.stderr)
             sys.exit(1)

--- a/skills/nav-graph/functions/graph_manager.py
+++ b/skills/nav-graph/functions/graph_manager.py
@@ -8,7 +8,7 @@ Manages .agent/knowledge/graph.json for unified knowledge retrieval.
 import json
 import sys
 import argparse
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -36,7 +36,7 @@ def save_graph(graph_path: str, graph: dict) -> bool:
         path.parent.mkdir(parents=True, exist_ok=True)
 
         # Update metadata
-        graph["last_updated"] = datetime.now().isoformat() + "Z"
+        graph["last_updated"] = datetime.now(timezone.utc).isoformat()
         graph["stats"] = calculate_stats(graph)
 
         with open(path, 'w') as f:
@@ -51,7 +51,7 @@ def create_empty_graph() -> dict:
     """Create a new empty graph structure."""
     return {
         "version": "1.0.0",
-        "last_updated": datetime.now().isoformat() + "Z",
+        "last_updated": datetime.now(timezone.utc).isoformat(),
         "stats": {
             "total_nodes": 0,
             "total_edges": 0,
@@ -153,6 +153,28 @@ def add_edge(graph: dict, from_id: str, to_id: str,
     return graph
 
 
+def _clamp_confidence(confidence: float) -> float:
+    """Coerce a confidence to the valid [0.0, 1.0] range.
+
+    Memory confidence is a probability-like score. Callers passing values
+    outside [0,1] (e.g. a percentage like 90) are clamped rather than allowed
+    to poison the graph — mem-026 shipped at 90.0 and rendered as "9000%".
+    Out-of-range repair of *existing* data uses a percentage heuristic; this
+    input guard simply clamps.
+    """
+    try:
+        c = float(confidence)
+    except (TypeError, ValueError):
+        return 0.8
+    if c < 0.0:
+        return 0.0
+    if c > 1.0:
+        print(f"warning: confidence {c} out of range [0,1]; clamping to 1.0",
+              file=sys.stderr)
+        return 1.0
+    return c
+
+
 def resolve_concept_alias(graph: dict, query: str) -> str:
     """Resolve a query term to canonical concept name via aliases."""
     query_lower = query.lower()
@@ -229,7 +251,9 @@ def query_by_concept(graph: dict, concept: str) -> dict:
         "memories": "memories",
         "sops": "sops",
         "system": "system",
-        "files": "files"
+        "files": "files",
+        "markers": "markers",
+        "concepts": "concepts",
     }
 
     results = {
@@ -239,7 +263,9 @@ def query_by_concept(graph: dict, concept: str) -> dict:
         "memories": [],
         "sops": [],
         "system": [],
-        "files": []
+        "files": [],
+        "markers": [],
+        "concepts": [],
     }
 
     # Query using resolved concept
@@ -344,6 +370,7 @@ def add_memory(graph: dict, memory_type: str, summary: str,
     check against the graph). If omitted, the next free ID is computed via
     `_next_memory_id` which scans both graph nodes and on-disk files.
     """
+    confidence = _clamp_confidence(confidence)
     memories = graph["nodes"].get("memories", {})
     if memory_id is None:
         memory_id = _next_memory_id(memories, base_dir)
@@ -362,8 +389,8 @@ def add_memory(graph: dict, memory_type: str, summary: str,
         "path": path,
         "confidence": confidence,
         "concepts": concepts,
-        "created": datetime.now().strftime("%Y-%m-%d"),
-        "last_validated": datetime.now().strftime("%Y-%m-%d")
+        "created": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+        "last_validated": datetime.now(timezone.utc).strftime("%Y-%m-%d")
     }
 
     graph = add_node(graph, "memories", memory_id, memory_data)
@@ -404,28 +431,27 @@ def update_confidence(graph: dict, memory_id: str,
         return 0.0
 
     memory = graph["nodes"]["memories"][memory_id]
-    confidence = memory.get("confidence", 0.8)
+    # Defensive: clamp any pre-existing out-of-range value before math so a
+    # poisoned node (e.g. 90.0) cannot propagate through decay/boost.
+    confidence = _clamp_confidence(memory.get("confidence", 0.8))
 
     # Apply decay (1% per week = ~0.14% per day)
     if decay_days > 0:
         decay_rate = 0.01 / 7  # 1% per week
         confidence -= decay_rate * decay_days
 
-    # Apply boost (5% per use, max +25%)
+    # Apply boost (5% per use), capped at the [0,1] ceiling. No fixed-0.8
+    # anchor — that broke for memories that had decayed or been elevated.
     if boost:
-        boost_amount = 0.05
-        max_boost = 0.25
-        current_boost = confidence - 0.8  # Assuming base 0.8
-        if current_boost < max_boost:
-            confidence = min(confidence + boost_amount, 0.8 + max_boost)
+        confidence = min(confidence + 0.05, 1.0)
 
     # Clamp to valid range
     confidence = max(0.0, min(1.0, confidence))
 
     memory["confidence"] = round(confidence, 2)
-    memory["last_validated"] = datetime.now().strftime("%Y-%m-%d")
+    memory["last_validated"] = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
-    return confidence
+    return memory["confidence"]
 
 
 def _format_task(task: dict) -> str:
@@ -454,6 +480,16 @@ def _format_file(file_node: dict) -> str:
     return f"  - {file_node.get('path', file_node.get('id', 'Unknown'))}"
 
 
+def _format_marker(marker: dict) -> str:
+    """Format a single context marker for display."""
+    return f"  - {marker.get('title', marker.get('id', 'Unknown'))}"
+
+
+def _format_concept(concept: dict) -> str:
+    """Format a single concept node for display."""
+    return f"  - {concept.get('name', concept.get('id', 'Unknown'))}"
+
+
 def format_query_results(results: dict) -> str:
     """Format query results for display."""
     concept = results.get("concept", "Unknown")
@@ -468,6 +504,8 @@ def format_query_results(results: dict) -> str:
     memories = results.get("memories", [])
     sops = results.get("sops", [])
     files = results.get("files", [])
+    markers = results.get("markers", [])
+    concepts = results.get("concepts", [])
 
     if tasks:
         output.append(f"TASKS ({len(tasks)})")
@@ -486,7 +524,15 @@ def format_query_results(results: dict) -> str:
         output.append(f"\nFILES ({len(files)})")
         output.extend(_format_file(f) for f in files[:5])
 
-    if any([tasks, memories, sops, files]):
+    if markers:
+        output.append(f"\nMARKERS ({len(markers)})")
+        output.extend(_format_marker(m) for m in markers[:5])
+
+    if concepts:
+        output.append(f"\nCONCEPTS ({len(concepts)})")
+        output.extend(_format_concept(c) for c in concepts[:5])
+
+    if any([tasks, memories, sops, files, markers, concepts]):
         output.append("\nLoad details: \"Read TASK-XX\" or \"Show [concept] memories\"")
     else:
         output.append("No results found for this concept.")

--- a/skills/nav-graph/functions/test_graph_maintenance.py
+++ b/skills/nav-graph/functions/test_graph_maintenance.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Tests for graph_maintenance.py integrity + decay logic (wp6 / TASK-47).
+
+stdlib unittest, direct-import style. First Python coverage for nav-graph
+maintenance: repair (dedup / dangling / confidence), health-check defect
+counts, prune empty-key cleanup, and idempotent decay.
+"""
+
+import sys
+import json
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from graph_manager import create_empty_graph, add_node
+from graph_maintenance import (
+    find_duplicate_edges,
+    find_dangling_edges,
+    find_out_of_range_confidence,
+    repair_graph,
+    health_check,
+    prune_memories,
+    apply_decay,
+    _read_decay_rate,
+    DEFAULT_DECAY_RATE,
+)
+
+
+def _mem(graph, mem_id, confidence=0.8, concepts=None, last_validated="2026-01-01",
+         last_decayed=None):
+    data = {
+        "type": "pattern",
+        "summary": "x",
+        "confidence": confidence,
+        "concepts": concepts or [],
+        "last_validated": last_validated,
+    }
+    if last_decayed:
+        data["last_decayed"] = last_decayed
+    return add_node(graph, "memories", mem_id, data)
+
+
+def _two_task_graph():
+    g = create_empty_graph()
+    g = add_node(g, "tasks", "TASK-01", {"concepts": []})
+    g = add_node(g, "tasks", "TASK-02", {"concepts": []})
+    return g
+
+
+class TestDetectors(unittest.TestCase):
+    def test_find_duplicate_edges(self):
+        g = _two_task_graph()
+        g["edges"] = [
+            {"from": "TASK-01", "to": "TASK-02", "type": "relates-to"},
+            {"from": "TASK-01", "to": "TASK-02", "type": "relates-to"},  # dup
+            {"from": "TASK-02", "to": "TASK-01", "type": "relates-to"},  # distinct
+        ]
+        self.assertEqual(find_duplicate_edges(g), 1)
+
+    def test_find_dangling_edges(self):
+        g = _two_task_graph()
+        g["edges"] = [
+            {"from": "TASK-01", "to": "TASK-02", "type": "relates-to"},
+            {"from": "TASK-01", "to": "GHOST", "type": "relates-to"},  # dangling
+        ]
+        dangling = find_dangling_edges(g)
+        self.assertEqual(len(dangling), 1)
+        self.assertEqual(dangling[0]["to"], "GHOST")
+
+    def test_find_out_of_range_confidence(self):
+        g = create_empty_graph()
+        g = _mem(g, "mem-001", confidence=90.0)
+        g = _mem(g, "mem-002", confidence=0.5)
+        oor = find_out_of_range_confidence(g)
+        self.assertEqual([m[0] for m in oor], ["mem-001"])
+
+
+class TestRepair(unittest.TestCase):
+    def _defective_graph(self):
+        g = _two_task_graph()
+        g["edges"] = [
+            {"from": "TASK-01", "to": "TASK-02", "type": "relates-to"},
+            {"from": "TASK-01", "to": "TASK-02", "type": "relates-to"},  # dup
+            {"from": "TASK-01", "to": "GHOST", "type": "relates-to"},    # dangling
+        ]
+        g = _mem(g, "mem-001", confidence=90.0)
+        return g
+
+    def test_repair_fixes_all_defects(self):
+        g = self._defective_graph()
+        summary = repair_graph(g)
+        self.assertEqual(summary["duplicates_removed"], 1)
+        self.assertEqual(summary["dangling_removed"], 1)
+        self.assertEqual(summary["confidences_normalized"], 1)
+        self.assertEqual(len(g["edges"]), 1)
+        self.assertEqual(g["nodes"]["memories"]["mem-001"]["confidence"], 0.9)
+        # No edge references an absent node id.
+        node_ids = {nid for bucket in g["nodes"].values() for nid in bucket}
+        for e in g["edges"]:
+            self.assertIn(e["from"], node_ids)
+            self.assertIn(e["to"], node_ids)
+
+    def test_repair_is_idempotent(self):
+        g = self._defective_graph()
+        repair_graph(g)
+        second = repair_graph(g)
+        self.assertEqual(
+            (second["duplicates_removed"], second["dangling_removed"],
+             second["confidences_normalized"]),
+            (0, 0, 0),
+        )
+
+
+class TestHealthCheck(unittest.TestCase):
+    def test_health_reports_integrity_metrics(self):
+        g = _two_task_graph()
+        g["edges"] = [
+            {"from": "TASK-01", "to": "TASK-02", "type": "relates-to"},
+            {"from": "TASK-01", "to": "TASK-02", "type": "relates-to"},  # dup
+            {"from": "TASK-01", "to": "GHOST", "type": "relates-to"},    # dangling
+        ]
+        g = _mem(g, "mem-001", confidence=90.0)
+        h = health_check(g)
+        self.assertEqual(h["duplicate_edges"], 1)
+        self.assertEqual(h["dangling_edges"], 1)
+        self.assertEqual(h["confidence_out_of_range"], 1)
+        # Conflicts/staleness are advisory, not score-affecting issues.
+        self.assertIn("advisory", h)
+
+    def test_clean_graph_has_zero_defects(self):
+        g = _two_task_graph()
+        g["edges"] = [{"from": "TASK-01", "to": "TASK-02", "type": "relates-to"}]
+        h = health_check(g)
+        self.assertEqual(
+            (h["duplicate_edges"], h["dangling_edges"], h["confidence_out_of_range"]),
+            (0, 0, 0),
+        )
+
+
+class TestPrune(unittest.TestCase):
+    def test_prune_removes_empty_concept_keys(self):
+        g = create_empty_graph()
+        g = _mem(g, "mem-001", confidence=0.1, concepts=["lonely"])
+        result = prune_memories(g, threshold=0.3, dry_run=False)
+        self.assertEqual(result["removed"], 1)
+        self.assertNotIn("mem-001", g["nodes"]["memories"])
+        # The sole member left -> the concept key must be gone, not left empty.
+        self.assertNotIn("lonely", g["concept_index"])
+
+    def test_prune_keeps_shared_concept(self):
+        g = create_empty_graph()
+        g = _mem(g, "mem-001", confidence=0.1, concepts=["shared"])
+        g = _mem(g, "mem-002", confidence=0.9, concepts=["shared"])
+        prune_memories(g, threshold=0.3, dry_run=False)
+        self.assertIn("shared", g["concept_index"])
+        self.assertEqual(g["concept_index"]["shared"], ["mem-002"])
+
+
+class TestDecay(unittest.TestCase):
+    def test_decay_is_idempotent_same_day(self):
+        g = create_empty_graph()
+        g = _mem(g, "mem-001", confidence=0.8, last_validated="2026-01-01")
+        apply_decay(g, decay_rate=0.01, today=date(2026, 3, 1))
+        first = g["nodes"]["memories"]["mem-001"]["confidence"]
+        self.assertLess(first, 0.8)
+        self.assertEqual(g["nodes"]["memories"]["mem-001"]["last_decayed"], "2026-03-01")
+        # Second run on the SAME day must not decay further.
+        apply_decay(g, decay_rate=0.01, today=date(2026, 3, 1))
+        self.assertEqual(g["nodes"]["memories"]["mem-001"]["confidence"], first)
+
+    def test_decay_accrues_on_a_later_day(self):
+        g = create_empty_graph()
+        g = _mem(g, "mem-001", confidence=0.8, last_validated="2026-01-01")
+        apply_decay(g, decay_rate=0.01, today=date(2026, 3, 1))
+        first = g["nodes"]["memories"]["mem-001"]["confidence"]
+        apply_decay(g, decay_rate=0.01, today=date(2026, 4, 1))
+        self.assertLess(g["nodes"]["memories"]["mem-001"]["confidence"], first)
+
+    def test_decay_reads_rate_from_config_when_none(self):
+        g = create_empty_graph()
+        g = _mem(g, "mem-001", confidence=0.8, last_validated="2026-01-01")
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "cfg.json"
+            cfg.write_text(json.dumps({"knowledge_graph": {"confidence_decay_rate": 0.5}}))
+            apply_decay(g, decay_rate=None, config_path=str(cfg), today=date(2026, 3, 1))
+        # High rate -> large drop (much lower than a 0.01 rate would give).
+        self.assertLess(g["nodes"]["memories"]["mem-001"]["confidence"], 0.5)
+
+
+class TestReadDecayRate(unittest.TestCase):
+    def test_reads_from_config(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "cfg.json"
+            cfg.write_text(json.dumps({"knowledge_graph": {"confidence_decay_rate": 0.05}}))
+            self.assertEqual(_read_decay_rate(str(cfg)), 0.05)
+
+    def test_missing_file_returns_default(self):
+        self.assertEqual(_read_decay_rate("/no/such/file.json"), DEFAULT_DECAY_RATE)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/skills/nav-graph/functions/test_graph_manager.py
+++ b/skills/nav-graph/functions/test_graph_manager.py
@@ -17,6 +17,10 @@ from graph_manager import (
     add_node,
     remove_node,
     add_edge,
+    add_memory,
+    query_by_concept,
+    format_query_results,
+    _clamp_confidence,
 )
 
 EMPTY_GRAPH_KEYS = {
@@ -240,6 +244,58 @@ class TestAddEdge(unittest.TestCase):
 
         self.assertNotIn("weight", graph["edges"][0])
         self.assertEqual(graph["edges"][1]["weight"], 0.5)
+
+
+class TestQueryByConcept(unittest.TestCase):
+    """query_by_concept must surface markers and concepts, not silently drop them."""
+
+    def test_markers_are_returned(self):
+        graph = create_empty_graph()
+        graph = add_node(
+            graph, "markers", "marker-1",
+            {"title": "My Marker", "concepts": ["auth"]},
+        )
+        results = query_by_concept(graph, "auth")
+        ids = [m["id"] for m in results["markers"]]
+        self.assertIn("marker-1", ids)
+
+    def test_markers_render_in_output(self):
+        graph = create_empty_graph()
+        graph = add_node(
+            graph, "markers", "marker-1",
+            {"title": "Release Marker", "concepts": ["auth"]},
+        )
+        rendered = format_query_results(query_by_concept(graph, "auth"))
+        self.assertIn("MARKERS", rendered)
+        self.assertIn("Release Marker", rendered)
+
+    def test_tasks_still_returned(self):
+        graph = create_empty_graph()
+        graph = add_node(
+            graph, "tasks", "TASK-01", {"title": "T", "concepts": ["auth"]},
+        )
+        results = query_by_concept(graph, "auth")
+        self.assertEqual([t["id"] for t in results["tasks"]], ["TASK-01"])
+
+
+class TestConfidenceClamp(unittest.TestCase):
+    """Confidence must be coerced to [0,1] on input (mem-026 was 90.0)."""
+
+    def test_clamp_bounds(self):
+        self.assertEqual(_clamp_confidence(90.0), 1.0)
+        self.assertEqual(_clamp_confidence(-0.5), 0.0)
+        self.assertEqual(_clamp_confidence(0.7), 0.7)
+
+    def test_clamp_non_numeric_falls_back(self):
+        self.assertEqual(_clamp_confidence("oops"), 0.8)
+
+    def test_add_memory_clamps_out_of_range(self):
+        graph = create_empty_graph()
+        mem_id = add_memory(
+            graph, "pattern", "summary", ["auth"],
+            confidence=5.0, create_file=False,
+        )
+        self.assertLessEqual(graph["nodes"]["memories"][mem_id]["confidence"], 1.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## wp6 / TASK-47 — Knowledge-graph data integrity + dormant maintenance

Phase 3 (critical-path tail) of the audit remediation roadmap (TASK-42). Depends on wp4 (#13). **Mutates the git-tracked `.agent/knowledge/graph.json`** via a committed, re-runnable repair — not a hand-edit.

### Track A — data repair + integrity (shipped)
- **`graph_maintenance --action repair`** — idempotent: dedupe `(from,to,type)` edge rows, drop edges referencing an absent node id, normalize out-of-range confidences (`90.0` → `0.9`). Ran on the live graph: **886 → 706 edges** (170 duplicate + 10 dangling removed), **mem-026 `90.0` → `0.9`**.
- **`health_check`** now reports `Duplicate Edges` / `Dangling Edges` / `Confidence Out-of-Range` (the integrity gate — all `0` post-repair, score `100/100`). The conflict + staleness heuristics are demoted to a non-scored **advisory** list.
- **`query_by_concept`** no longer silently drops `markers`/`concepts` node types (verified live: 9 markers now surface under "database"). Added `_format_marker`/`_format_concept`.
- **`graph_builder`** routes inferred edges through `add_edge` (dedup) behind a referential-integrity filter, so a rebuild can't reintroduce dup/dangling.
- Confidence clamped to `[0,1]` on input (`add_memory`/`update_confidence`); dropped the broken fixed-`0.8` boost anchor; UTC timestamps throughout.
- `prune_memories` drops emptied `concept_index` keys (mirrors `remove_node`).

### Track B — idempotent decay (manual-only, per DEFER guidance)
- `apply_decay` is now idempotent (per-memory `last_decayed`, throttled to ≤1/day) and reads `confidence_decay_rate` from config; `--action stale` reads `staleness_threshold_days` (both config keys were previously read by zero code).
- **Decay is NOT hook-wired** — auto-decay on session start would churn a git-tracked file every session. Marked experimental/manual in SKILL.md. This satisfies the idempotency acceptance criterion without the risky session-start mutation.

### Tests
- **+20 tests** (nav-graph 15 → 35): repair idempotency, defect detectors, health integrity metrics, prune empty-key cleanup, decay idempotency/config, query markers, confidence clamp. `make test` green.

### Acceptance (live-verified)
`health` → 0 duplicate / 0 dangling / 0 out-of-range; 706 unique edges; no edge references an absent node; mem-026 `0.9` (renders 90%); marker query lists markers; repair re-run is a no-op.