### PR TITLE
fix(graph): stop task-sync dangling-edge leak; finalize TASK-47 (wp6)

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -1,9 +1,9 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-06-03T10:41:10.574127+00:00",
+  "last_updated": "2026-06-03T10:47:04.742506+00:00",
   "stats": {
-    "total_nodes": 133,
-    "total_edges": 706,
+    "total_nodes": 134,
+    "total_edges": 713,
     "memory_count": 37
   },
   "nodes": {
@@ -601,6 +601,21 @@
           "markers",
           "context",
           "deployment"
+        ]
+      },
+      "TASK-47": {
+        "path": "/Users/aleks.petrov/Projects/startups/navigator/.agent/tasks/TASK-47-kg-integrity.md",
+        "title": "Knowledge-graph data integrity + dormant maintenance wiring",
+        "status": "completed",
+        "concepts": [
+          "database",
+          "tom",
+          "deployment",
+          "knowledge",
+          "context",
+          "skills",
+          "markers",
+          "testing"
         ]
       }
     },
@@ -5784,6 +5799,41 @@
       "from": "TASK-46",
       "to": "deployment",
       "type": "implements"
+    },
+    {
+      "from": "TASK-47",
+      "to": "database",
+      "type": "implements"
+    },
+    {
+      "from": "TASK-47",
+      "to": "deployment",
+      "type": "implements"
+    },
+    {
+      "from": "TASK-47",
+      "to": "knowledge",
+      "type": "implements"
+    },
+    {
+      "from": "TASK-47",
+      "to": "context",
+      "type": "implements"
+    },
+    {
+      "from": "TASK-47",
+      "to": "skills",
+      "type": "implements"
+    },
+    {
+      "from": "TASK-47",
+      "to": "markers",
+      "type": "implements"
+    },
+    {
+      "from": "TASK-47",
+      "to": "testing",
+      "type": "implements"
     }
   ],
   "concept_index": {
@@ -5819,7 +5869,8 @@
       "TASK-38",
       "TASK-41",
       "TASK-40",
-      "TASK-50"
+      "TASK-50",
+      "TASK-47"
     ],
     "testing": [
       "TASK-32",
@@ -5897,7 +5948,8 @@
       "TASK-44",
       "TASK-50",
       "TASK-45",
-      "TASK-46"
+      "TASK-46",
+      "TASK-47"
     ],
     "context": [
       "TASK-32",
@@ -5975,7 +6027,8 @@
       "TASK-40",
       "TASK-44",
       "TASK-45",
-      "TASK-46"
+      "TASK-46",
+      "TASK-47"
     ],
     "skills": [
       "TASK-32",
@@ -6060,7 +6113,8 @@
       "TASK-44",
       "TASK-50",
       "TASK-45",
-      "TASK-46"
+      "TASK-46",
+      "TASK-47"
     ],
     "session": [
       "TASK-32",
@@ -6348,7 +6402,8 @@
       "TASK-41",
       "TASK-40",
       "TASK-45",
-      "TASK-46"
+      "TASK-46",
+      "TASK-47"
     ],
     "deployment": [
       "TASK-11",
@@ -6376,7 +6431,8 @@
       "TASK-44",
       "TASK-50",
       "TASK-45",
-      "TASK-46"
+      "TASK-46",
+      "TASK-47"
     ],
     "code quality": [
       "TASK-19",
@@ -6415,7 +6471,8 @@
       "TASK-44",
       "TASK-50",
       "TASK-45",
-      "TASK-46"
+      "TASK-46",
+      "TASK-47"
     ],
     "theory of mind": [
       "TASK-19",
@@ -6537,7 +6594,8 @@
       "TASK-44",
       "TASK-50",
       "TASK-45",
-      "TASK-46"
+      "TASK-46",
+      "TASK-47"
     ],
     "general": [
       "mem-028",

--- a/.agent/tasks/TASK-47-kg-integrity.md
+++ b/.agent/tasks/TASK-47-kg-integrity.md
@@ -1,6 +1,6 @@
 # TASK-47: Knowledge-graph data integrity + dormant maintenance wiring
 
-**Status**: 📋 Planned
+**Status**: ✅ Implemented — 2026-06-03 (PR #16; Track B decay = idempotent + manual-only/experimental, not hook-wired)
 **Created**: 2026-06-02
 **Work-package**: `wp6-kg-integrity`
 **Phase**: 3 — Behavioral fixes (guarded)

--- a/skills/nav-graph/functions/task_to_graph.py
+++ b/skills/nav-graph/functions/task_to_graph.py
@@ -51,8 +51,8 @@ def extract_concepts_from_task(content: str) -> list:
         'token': 'context',
         'memory': 'knowledge',
         'graph': 'knowledge',
-        'profile': 'tom',
-        'tom': 'tom',
+        'profile': 'theory of mind',
+        'tom': 'theory of mind',
         'loop': 'workflow',
         'task.mode': 'workflow',
         'simplif': 'simplification',
@@ -151,9 +151,16 @@ def add_task_to_graph(task_path: str, graph_path: str) -> dict:
 
     graph = add_node(graph, 'tasks', task_id, task_data)
 
-    # Add implements edges for concepts
+    # Add 'implements' edges only to concepts that exist as concept nodes
+    # (referential integrity — keyword_map may yield a concept with no
+    # canonical node, e.g. a fresh project that has not run a full build).
+    # Without this filter every task edit re-introduces a dangling edge that
+    # the wp6 repair then has to clean. The task is still indexed under every
+    # concept via add_node, so query_by_concept still finds it.
+    concept_nodes = graph.get('nodes', {}).get('concepts', {})
     for concept in concepts:
-        graph = add_edge(graph, task_id, concept, 'implements')
+        if concept in concept_nodes:
+            graph = add_edge(graph, task_id, concept, 'implements')
 
     # Extract and create decision memories (for completed tasks)
     memories_created = []

--- a/skills/nav-graph/functions/test_task_to_graph.py
+++ b/skills/nav-graph/functions/test_task_to_graph.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Tests for task_to_graph.add_task_to_graph referential integrity (wp6 follow-up).
+
+The PostToolUse task-sync hook must not re-introduce dangling 'implements'
+edges. Before the fix, keyword_map produced concept 'tom' (no canonical node)
+and an unconditional edge, so every task edit poisoned the graph with a
+dangling edge that --action repair then had to clean.
+"""
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from graph_manager import create_empty_graph, save_graph, load_graph, add_node
+from graph_maintenance import find_dangling_edges
+from task_to_graph import add_task_to_graph
+
+
+class TaskSyncIntegrityTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.graph_path = self.root / "graph.json"
+        graph = create_empty_graph()
+        # Only the canonical 'theory of mind' concept exists as a node.
+        graph = add_node(
+            graph, "concepts", "theory of mind",
+            {"name": "Theory of Mind", "aliases": ["tom", "profile"]},
+        )
+        save_graph(str(self.graph_path), graph)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _write_task(self, name: str, body: str) -> Path:
+        path = self.root / name
+        path.write_text(body)
+        return path
+
+    def test_sync_creates_no_dangling_edges(self):
+        # 'profile' -> 'theory of mind' (node exists -> edge ok);
+        # 'deploy' -> 'deployment' (no node -> edge filtered, not dangling).
+        task = self._write_task(
+            "TASK-77.md",
+            "# TASK-77: x\n\nWork on the user profile and deployment pipeline.\n",
+        )
+        add_task_to_graph(str(task), str(self.graph_path))
+        graph = load_graph(str(self.graph_path))
+        self.assertEqual(find_dangling_edges(graph), [])
+
+    def test_canonical_concept_edge_is_added(self):
+        # 'profile'/'tom' both normalize to the canonical 'theory of mind' node.
+        task = self._write_task(
+            "TASK-78.md",
+            "# TASK-78: x\n\nImprove the profile / tom modeling.\n",
+        )
+        add_task_to_graph(str(task), str(self.graph_path))
+        graph = load_graph(str(self.graph_path))
+        edges = [(e["from"], e["to"]) for e in graph["edges"]]
+        self.assertIn(("TASK-78", "theory of mind"), edges)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Follow-up to #16 (wp6/TASK-47). Surfaced while finalizing: the PostToolUse task-sync (`task_to_graph.add_task_to_graph`) re-introduced a dangling `implements` edge on **every task edit** — keyword_map mapped `profile`/`tom` → `'tom'` (no canonical concept node) and added the edge unconditionally, undoing the wp6 repair each time.

- Normalize keyword_map `profile`/`tom` → `'theory of mind'` (canonical node, matching `graph_builder`).
- Referential-integrity filter: only emit an `implements` edge when the concept exists as a concept node. Task is still indexed under every concept via `add_node`, so `query_by_concept` is unaffected.
- +2 tests (no dangling after sync; canonical edge still added).
- Finalizes TASK-47 status and commits the repaired `graph.json` (713 edges; health 0/0/0).