### PR TITLE
fix(python): misc correctness fixes across skill helpers (TASK-51)

### DIFF
--- a/.agent/tasks/TASK-51-python-misc.md
+++ b/.agent/tasks/TASK-51-python-misc.md
@@ -1,6 +1,6 @@
 # TASK-51: Misc Python correctness fixes
 
-**Status**: 📋 Planned
+**Status**: ✅ Implemented — 2026-06-03
 **Created**: 2026-06-02
 **Work-package**: `wp11-python-misc`
 **Phase**: 4 — Independent tracks (parallel)
@@ -61,14 +61,30 @@ Tests: there is no pytest run in CI (release.yml has no test step) but sibling s
 
 ## Acceptance Criteria
 
-- [ ] correction_to_memory.py: after sync_corrections_to_graph adds N memories, check_for_new_corrections reports synced_memories == N and pending == 0 (test asserts this on a temp profile+graph)
-- [ ] Existing non-correction memories (no source field) are NOT counted as synced
-- [ ] task_id_generator: get_next_task_id counts both TASK-09.md and TASK-09-name.md (test or manual: a dir with only TASK-09.md returns TASK-10, not TASK-01)
-- [ ] progress_tracker: update_progress/get_progress/get_next_task on a corrupt or partial .progress-data.json return an {"error":...} dict (or None for get_next_task) instead of raising JSONDecodeError/KeyError
-- [ ] feature_manager: check_installed uses no shell=True; KeyboardInterrupt is no longer swallowed; multi_claude_scripts feature still reports installed/not-installed correctly
-- [ ] release_validator: _strip_dot_slash('./skills/x')=='skills/x', ('skills/x')=='skills/x', ('./a/.b')=='a/.b'; --check-all still passes against current plugin.json
-- [ ] profile_manager: add_goal with a goal dict lacking 'name' returns/raises a clear error and does not crash; legacy goals without 'name' do not break dedup
-- [ ] All new test_*.py files pass via `python3 <test_file>`
+- [x] correction_to_memory.py: after sync_corrections_to_graph adds N memories, check_for_new_corrections reports synced_memories == N and pending == 0 (test asserts this on a temp profile+graph)
+- [x] Existing non-correction memories (no source field) are NOT counted as synced
+- [x] task_id_generator: get_next_task_id counts both TASK-09.md and TASK-09-name.md (verified: a dir with only TASK-09.md returns TASK-10)
+- [x] progress_tracker: update_progress/get_progress/get_next_task on a corrupt or partial .progress-data.json return an {"error":...} dict (or None for get_next_task) instead of raising JSONDecodeError/KeyError
+- [x] feature_manager: check_installed uses no shell=True; KeyboardInterrupt is no longer swallowed; multi_claude_scripts feature still reports installed/not-installed correctly (shutil.which)
+- [x] release_validator: _strip_dot_slash('./skills/x')=='skills/x', ('skills/x')=='skills/x', ('./a/.b')=='a/.b'; --check-all passes on a clean tree
+- [x] profile_manager: add_goal with a goal dict lacking 'name' returns the profile unchanged with a clear stderr error and does not crash; legacy goals without 'name' do not break dedup
+- [x] All new test_*.py files pass via `make test`
+
+## Implementation Notes (2026-06-03)
+
+- `add_memory` gained an optional `source` param (persisted on the node only
+  when provided → backward-compatible); `correction_to_memory` tags its memories
+  `source='correction'` and counts those.
+- `feature_manager.check_installed` rewritten to `shutil.which` (no subprocess,
+  no `shell=True`, no bare `except:`) — resolves the final token of the probe.
+- **Stale-assumption catch**: the plan said to create
+  `test_release_validator.py`, but wp1/wp2 already created it — appended a
+  `StripDotSlashTest` class instead of overwriting.
+- Added `skills/nav-onboard/functions` to the Makefile `TEST_DIRS` (it was
+  absent, so the new progress_tracker test would not have run in CI).
+- Verified out of scope and left untouched: `release_validator.py` main()'s
+  `args.check_version.lstrip("v")` (display-only, guarded) is a separate
+  latent bug not in this work-package's findings.
 
 ## Technical Decisions
 
@@ -90,6 +106,6 @@ Tests: there is no pytest run in CI (release.yml has no test step) but sibling s
 
 ## Done
 
-- [ ] All acceptance criteria checked
-- [ ] Tests pass in CI (once TASK-43 gate exists)
-- [ ] Committed + roadmap (TASK-42) status updated
+- [x] All acceptance criteria checked
+- [x] Tests pass in CI (TASK-43 gate runs `make test`)
+- [x] Committed + roadmap (TASK-42) status updated

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ TEST_DIRS := \
 	skills/nav-release/functions \
 	skills/nav-start/functions \
 	skills/nav-graph/functions \
+	skills/nav-onboard/functions \
 	skills/nav-profile/functions
 
 # Standalone shell test scripts (each exits non-zero on failure).

--- a/skills/nav-features/functions/feature_manager.py
+++ b/skills/nav-features/functions/feature_manager.py
@@ -12,6 +12,8 @@ Usage:
 
 import sys
 import json
+import shlex
+import shutil
 import argparse
 from pathlib import Path
 from typing import Dict, Any, Optional, Tuple
@@ -203,18 +205,18 @@ def save_config(config: Dict) -> Optional[str]:
 
 
 def check_installed(check_command: str) -> bool:
-    """Check if a command/script is installed."""
-    import subprocess
-    try:
-        result = subprocess.run(
-            check_command,
-            shell=True,
-            capture_output=True,
-            timeout=5
-        )
-        return result.returncode == 0
-    except:
+    """Return True if the feature's executable resolves on PATH.
+
+    The only installed-type feature probes with `command -v <script>`. We
+    resolve the final token (the script name) via shutil.which rather than
+    spawning `shell=True` under a bare `except:`, so KeyboardInterrupt and
+    SystemExit are never swallowed and no shell parsing is involved.
+    """
+    if not check_command:
         return False
+    tokens = shlex.split(check_command)
+    executable = tokens[-1] if tokens else ""
+    return bool(executable) and shutil.which(executable) is not None
 
 
 def is_feature_enabled(config: Dict, feature_name: str) -> bool:

--- a/skills/nav-graph/functions/correction_to_memory.py
+++ b/skills/nav-graph/functions/correction_to_memory.py
@@ -106,6 +106,7 @@ def _correction_to_memory_in_graph(correction: dict, graph: dict) -> str:
         concepts=concepts,
         confidence=confidence,
         source_task=None,
+        source='correction',
     )
 
 
@@ -173,11 +174,12 @@ def check_for_new_corrections(profile_path: str, graph_path: str) -> dict:
 
     correction_count = len(profile.get('corrections', []))
 
-    # Check how many corrections we've already synced
-    # We track this by counting memories with no source_task (correction-based)
+    # Count memories tagged at creation as correction-derived. Memories from
+    # other sources (and legacy memories lacking the 'source' field) are not
+    # counted, so this reflects only what sync_corrections_to_graph produced.
     synced_count = sum(
         1 for m in graph['nodes'].get('memories', {}).values()
-        if 'learned-from' not in str(graph.get('edges', []))
+        if m.get('source') == 'correction'
     )
 
     return {

--- a/skills/nav-graph/functions/graph_manager.py
+++ b/skills/nav-graph/functions/graph_manager.py
@@ -357,7 +357,8 @@ def add_memory(graph: dict, memory_type: str, summary: str,
                source_task: Optional[str] = None,
                base_dir: str = ".agent/knowledge",
                create_file: bool = True,
-               memory_id: Optional[str] = None) -> str:
+               memory_id: Optional[str] = None,
+               source: Optional[str] = None) -> str:
     """Add a memory node to the graph.
 
     Also creates the backing markdown file at
@@ -369,6 +370,10 @@ def add_memory(graph: dict, memory_type: str, summary: str,
     If `memory_id` is provided, that ID is used directly (after collision
     check against the graph). If omitted, the next free ID is computed via
     `_next_memory_id` which scans both graph nodes and on-disk files.
+
+    `source` tags the origin of the memory (e.g. 'correction' for memories
+    derived from profile corrections). It is persisted on the node only when
+    provided, so nodes created without it keep their existing shape.
     """
     confidence = _clamp_confidence(confidence)
     memories = graph["nodes"].get("memories", {})
@@ -392,6 +397,8 @@ def add_memory(graph: dict, memory_type: str, summary: str,
         "created": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
         "last_validated": datetime.now(timezone.utc).strftime("%Y-%m-%d")
     }
+    if source:
+        memory_data["source"] = source
 
     graph = add_node(graph, "memories", memory_id, memory_data)
 

--- a/skills/nav-graph/functions/test_correction_to_memory.py
+++ b/skills/nav-graph/functions/test_correction_to_memory.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Tests for correction_to_memory.py synced-count accounting.
+
+Covers the wp11/TASK-51 fix: check_for_new_corrections must count only
+memories tagged source=='correction' (set at creation), not every memory
+node and not a graph-wide edge string match.
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from correction_to_memory import (
+    sync_corrections_to_graph,
+    check_for_new_corrections,
+)
+from graph_manager import create_empty_graph, save_graph, add_memory
+
+
+class TestCorrectionSyncedCount(unittest.TestCase):
+    """check_for_new_corrections reports the real synced count."""
+
+    def setUp(self):
+        # chdir into a temp dir so add_memory's backing-file writes
+        # (base_dir='.agent/knowledge') land in the sandbox, not the repo.
+        self._cwd = os.getcwd()
+        self._tmp = tempfile.mkdtemp()
+        os.chdir(self._tmp)
+        self.profile_path = "profile.json"
+        self.graph_path = ".agent/knowledge/graph.json"
+
+    def tearDown(self):
+        os.chdir(self._cwd)
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _write_profile(self, n: int) -> int:
+        corrections = [
+            {
+                "context": f"context {i}",
+                "pattern": f"always do thing {i}",
+                "corrected_to": f"do thing {i}",
+                "confidence": "high",
+            }
+            for i in range(n)
+        ]
+        Path(self.profile_path).write_text(json.dumps({"corrections": corrections}))
+        return n
+
+    def test_synced_count_matches_added_memories(self):
+        n = self._write_profile(3)
+        result = sync_corrections_to_graph(self.profile_path, self.graph_path)
+        self.assertEqual(result["synced"], n)
+
+        check = check_for_new_corrections(self.profile_path, self.graph_path)
+        self.assertEqual(check["synced_memories"], n)
+        self.assertEqual(check["pending"], 0)
+
+    def test_non_correction_memories_not_counted(self):
+        # Seed a memory from a different origin (no 'source' field).
+        graph = create_empty_graph()
+        add_memory(graph, "pattern", "unrelated memory", ["general"],
+                   create_file=False)
+        save_graph(self.graph_path, graph)
+
+        n = self._write_profile(2)
+        sync_corrections_to_graph(self.profile_path, self.graph_path)
+
+        check = check_for_new_corrections(self.profile_path, self.graph_path)
+        # The seeded non-correction memory is excluded; only the 2 tagged
+        # correction memories count.
+        self.assertEqual(check["synced_memories"], n)
+        self.assertEqual(check["pending"], 0)
+
+    def test_empty_graph_reports_zero(self):
+        self._write_profile(0)
+        check = check_for_new_corrections(self.profile_path, self.graph_path)
+        self.assertEqual(check["synced_memories"], 0)
+        self.assertEqual(check["pending"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/nav-onboard/functions/progress_tracker.py
+++ b/skills/nav-onboard/functions/progress_tracker.py
@@ -132,18 +132,22 @@ def update_progress(
     if not data_file.exists():
         return {"error": "Progress not initialized. Run init first."}
 
-    data = json.loads(data_file.read_text())
+    try:
+        data = json.loads(data_file.read_text())
+    except json.JSONDecodeError:
+        return {"error": "Progress data corrupt"}
 
-    if skill_name not in data["progress"]:
+    progress = data.get("progress", {})
+    if skill_name not in progress:
         return {"error": f"Unknown skill: {skill_name}"}
 
     # Update skill status
-    data["progress"][skill_name]["status"] = status
+    progress[skill_name]["status"] = status
     if status == "completed":
-        data["progress"][skill_name]["completed"] = datetime.now().strftime("%Y-%m-%d %H:%M")
-        data["completed"] = sum(1 for s in data["progress"].values() if s["status"] == "completed")
+        progress[skill_name]["completed"] = datetime.now().strftime("%Y-%m-%d %H:%M")
+        data["completed"] = sum(1 for s in progress.values() if s.get("status") == "completed")
     if notes:
-        data["progress"][skill_name]["notes"] = notes
+        progress[skill_name]["notes"] = notes
 
     # Save updated data
     data_file.write_text(json.dumps(data, indent=2))
@@ -151,12 +155,14 @@ def update_progress(
     # Regenerate markdown
     _regenerate_markdown(onboarding_dir, data)
 
+    total = data.get("total", 0)
+    completed = data.get("completed", 0)
     return {
         "skill": skill_name,
         "status": status,
-        "completed": data["completed"],
-        "total": data["total"],
-        "percentage": round(data["completed"] / data["total"] * 100) if data["total"] > 0 else 0,
+        "completed": completed,
+        "total": total,
+        "percentage": round(completed / total * 100) if total > 0 else 0,
         "next_task": get_next_task(project_dir),
     }
 
@@ -177,16 +183,21 @@ def get_progress(project_dir: str) -> Dict:
     if not data_file.exists():
         return {"initialized": False}
 
-    data = json.loads(data_file.read_text())
+    try:
+        data = json.loads(data_file.read_text())
+    except json.JSONDecodeError:
+        return {"error": "Progress data corrupt"}
 
+    total = data.get("total", 0)
+    completed = data.get("completed", 0)
     return {
         "initialized": True,
-        "flow_type": data["flow_type"],
-        "project_type": data["project_type"],
-        "completed": data["completed"],
-        "total": data["total"],
-        "percentage": round(data["completed"] / data["total"] * 100) if data["total"] > 0 else 0,
-        "skills": data["progress"],
+        "flow_type": data.get("flow_type"),
+        "project_type": data.get("project_type"),
+        "completed": completed,
+        "total": total,
+        "percentage": round(completed / total * 100) if total > 0 else 0,
+        "skills": data.get("progress", {}),
         "next_task": get_next_task(project_dir),
     }
 
@@ -207,12 +218,16 @@ def get_next_task(project_dir: str) -> Optional[str]:
     if not data_file.exists():
         return None
 
-    data = json.loads(data_file.read_text())
+    try:
+        data = json.loads(data_file.read_text())
+    except json.JSONDecodeError:
+        return None
 
     # Find first non-completed skill in order
-    all_skills = data["essential_skills"] + data["development_skills"]
+    all_skills = data.get("essential_skills", []) + data.get("development_skills", [])
+    progress = data.get("progress", {})
     for skill in all_skills:
-        if data["progress"][skill]["status"] != "completed":
+        if progress.get(skill, {}).get("status") != "completed":
             return skill
 
     return None

--- a/skills/nav-onboard/functions/test_progress_tracker.py
+++ b/skills/nav-onboard/functions/test_progress_tracker.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Tests for progress_tracker.py corrupt/partial-data resilience.
+
+Covers the wp11/TASK-51 fix: reading a corrupt or partial
+.progress-data.json must return an {"error": ...} dict (or None for
+get_next_task) instead of raising JSONDecodeError/KeyError.
+"""
+
+import json
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from progress_tracker import update_progress, get_progress, get_next_task
+
+
+class TestProgressTrackerResilience(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.onboarding = Path(self.tmp) / ".agent" / "onboarding"
+        self.onboarding.mkdir(parents=True)
+        self.data_file = self.onboarding / ".progress-data.json"
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write(self, text: str):
+        self.data_file.write_text(text)
+
+    # --- corrupt (invalid JSON) ---------------------------------------
+
+    def test_corrupt_get_progress_returns_error(self):
+        self._write("{ this is not valid json")
+        result = get_progress(self.tmp)
+        self.assertIn("error", result)
+
+    def test_corrupt_update_progress_returns_error(self):
+        self._write("}{ broken")
+        result = update_progress(self.tmp, "nav-start", "completed")
+        self.assertIn("error", result)
+
+    def test_corrupt_get_next_task_returns_none(self):
+        self._write("not json at all")
+        self.assertIsNone(get_next_task(self.tmp))
+
+    # --- partial (valid JSON, missing required keys) ------------------
+
+    def test_partial_data_does_not_crash(self):
+        self._write(json.dumps({"flow_type": "quick_start"}))
+        # All three must tolerate the missing 'progress'/'total' keys.
+        prog = get_progress(self.tmp)
+        self.assertIsInstance(prog, dict)
+        self.assertEqual(prog.get("percentage"), 0)
+
+        self.assertIsNone(get_next_task(self.tmp))
+
+        upd = update_progress(self.tmp, "nav-start", "completed")
+        self.assertIn("error", upd)  # unknown skill, not a KeyError crash
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/nav-profile/functions/profile_manager.py
+++ b/skills/nav-profile/functions/profile_manager.py
@@ -101,14 +101,23 @@ def add_correction(profile: dict, correction: dict) -> dict:
 
 
 def add_goal(profile: dict, goal: dict) -> dict:
-    """Add or update a goal in the profile."""
+    """Add or update a goal in the profile.
+
+    A goal must have a non-empty 'name'. If it doesn't, the profile is returned
+    unchanged with an error on stderr (callers save the profile as a no-op
+    rather than crashing). Dedup tolerates legacy goals that lack 'name'.
+    """
+    if not goal.get("name"):
+        print("Error: goal requires a 'name'", file=sys.stderr)
+        return profile
+
     if "goals" not in profile:
         profile["goals"] = []
 
     today = datetime.now().strftime("%Y-%m-%d")
 
     # Check if goal already exists
-    existing = next((g for g in profile["goals"] if g["name"] == goal["name"]), None)
+    existing = next((g for g in profile["goals"] if g.get("name") == goal["name"]), None)
 
     if existing:
         existing["last_mentioned"] = today

--- a/skills/nav-release/functions/release_validator.py
+++ b/skills/nav-release/functions/release_validator.py
@@ -26,6 +26,16 @@ from pathlib import Path
 from typing import List, Tuple, Dict
 
 
+def _strip_dot_slash(path: str) -> str:
+    """Strip a single leading './' from a path.
+
+    `str.lstrip("./")` strips ANY leading '.' and '/' characters, so it would
+    mangle a path whose first segment begins with a dot (e.g. './.config' →
+    'config'). This removes only the literal './' prefix.
+    """
+    return path[2:] if path.startswith("./") else path
+
+
 def get_project_root() -> Path:
     """Find project root (contains .claude-plugin/)."""
     current = Path.cwd()
@@ -58,7 +68,7 @@ def check_skills_exist(root: Path, plugin: dict) -> Tuple[List[str], List[str]]:
 
     for skill_path in skills:
         # Normalize path (remove ./ prefix)
-        clean_path = skill_path.lstrip("./")
+        clean_path = _strip_dot_slash(skill_path)
         skill_dir = root / clean_path
         skill_md = skill_dir / "SKILL.md"
 
@@ -109,7 +119,7 @@ def check_skills_committed(root: Path, plugin: dict) -> Tuple[List[str], List[st
 
     # Check each skill
     for skill_path in skills:
-        clean_path = skill_path.lstrip("./")
+        clean_path = _strip_dot_slash(skill_path)
 
         # Check if any file in skill dir is modified/untracked
         is_modified = any(p.startswith(clean_path) for p in modified_paths)
@@ -192,7 +202,7 @@ def verify_tag_contents(root: Path, tag: str) -> Tuple[List[str], List[str]]:
     missing = []
 
     for skill_path in skills:
-        clean_path = skill_path.lstrip("./")
+        clean_path = _strip_dot_slash(skill_path)
         skill_md_path = f"{clean_path}/SKILL.md"
 
         # Check if file exists in tag

--- a/skills/nav-release/functions/test_release_validator.py
+++ b/skills/nav-release/functions/test_release_validator.py
@@ -13,7 +13,11 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 
-from release_validator import verify_hook_paths, check_version_match  # noqa: E402
+from release_validator import (  # noqa: E402
+    verify_hook_paths,
+    check_version_match,
+    _strip_dot_slash,
+)
 
 
 def _make_root(tmp: Path, hook_names, manifest_hooks):
@@ -116,6 +120,24 @@ class CheckVersionMatchTest(unittest.TestCase):
                 "[![Version](https://img.shields.io/badge/version-6.15.5-blue.svg)](x)\n")
             _, mismatches = check_version_match(tmp, "6.15.6")
             self.assertTrue(any("README.md" in m for m in mismatches))
+
+
+class StripDotSlashTest(unittest.TestCase):
+    """wp11/TASK-51: prefix-only strip, not lstrip('./') char-class strip."""
+
+    def test_strips_leading_dot_slash(self):
+        self.assertEqual(_strip_dot_slash("./skills/x"), "skills/x")
+
+    def test_no_prefix_unchanged(self):
+        self.assertEqual(_strip_dot_slash("skills/x"), "skills/x")
+
+    def test_preserves_dot_segment_after_prefix(self):
+        self.assertEqual(_strip_dot_slash("./a/.b"), "a/.b")
+
+    def test_demonstrates_lstrip_bug_is_fixed(self):
+        # lstrip('./') eats the leading dot of a dotfile; the helper does not.
+        self.assertEqual("./.config".lstrip("./"), "config")
+        self.assertEqual(_strip_dot_slash("./.config"), ".config")
 
 
 if __name__ == "__main__":

--- a/skills/nav-task/functions/task_id_generator.py
+++ b/skills/nav-task/functions/task_id_generator.py
@@ -23,8 +23,8 @@ def get_next_task_id(agent_dir=".agent", prefix="TASK"):
     if not os.path.exists(tasks_dir):
         return f"{prefix}-01"
 
-    # Find all task files matching pattern TASK-XX-*.md
-    task_pattern = re.compile(rf"{prefix}-(\d+)-.*\.md")
+    # Find all task files matching TASK-XX.md or TASK-XX-name.md
+    task_pattern = re.compile(rf"{prefix}-(\d+)(?:-.*)?\.md")
     task_numbers = []
 
     for filename in os.listdir(tasks_dir):


### PR DESCRIPTION
## Summary

wp11 of the audit remediation roadmap (TASK-42). Six independent, single-file Python correctness defects from audit `wf_0dc1b9ce-7d8`, plus focused tests for the three non-trivial ones.

| Fix | File |
|-----|------|
| Count `source=='correction'` memories (was a loop-var-ignoring edge string match); `add_memory` gains optional, backward-compatible `source` field | `nav-graph/correction_to_memory.py`, `nav-graph/graph_manager.py` |
| Regex `TASK-(\d+)(?:-.*)?\.md` so plain `TASK-XX.md` is counted | `nav-task/task_id_generator.py` |
| Guard `json.loads` + `.get()` defaults → corrupt/partial data returns error dict, not a crash | `nav-onboard/progress_tracker.py` |
| `shutil.which` instead of `shell=True` under a bare `except:` (KeyboardInterrupt no longer swallowed) | `nav-features/feature_manager.py` |
| `_strip_dot_slash` helper replacing `lstrip('./')` (strips chars, not the prefix) at 3 sites | `nav-release/release_validator.py` |
| `add_goal` guards missing `'name'` + tolerates legacy nameless goals in dedup | `nav-profile/profile_manager.py` |

## Tests

- New `test_correction_to_memory.py` (synced-count + non-correction exclusion + empty graph)
- New `test_progress_tracker.py` (corrupt/partial resilience)
- Appended `StripDotSlashTest` to existing `test_release_validator.py`
- Added `skills/nav-onboard/functions` to Makefile `TEST_DIRS` — it was absent, so the new progress_tracker test would not have run in CI.

`make test` green locally (all dirs + shell tests).

## Notes

- `add_memory`'s `source` field is persisted only when provided → existing nodes keep their shape.
- Stale-assumption catch: plan said to create `test_release_validator.py`, but wp1/wp2 already had → appended a class instead of overwriting.
- Out of scope (left untouched): `release_validator` main()'s display-only `lstrip("v")` is a separate latent bug, not in this WP's findings.

Refs: TASK-51, TASK-42.