### PR TITLE
docs: sync Nav index + CLAUDE.md config sample to v6.15.7

### DIFF
--- a/.agent/DEVELOPMENT-README.md
+++ b/.agent/DEVELOPMENT-README.md
@@ -78,7 +78,7 @@ Strategic loading beats bulk loading.
 
 **Project**: Claude Code plugin for Navigator
 **Tech**: Markdown skills, JSON manifests, Python hook scripts
-**Plugin version**: see `.claude-plugin/plugin.json` (currently v6.15.6)
+**Plugin version**: see `.claude-plugin/plugin.json` (currently v6.15.7)
 
 **New here?** Read in order:
 1. [Project Architecture](./system/project-architecture.md) — plugin structure, manifest, hook wiring
@@ -178,9 +178,11 @@ For shipped scope, query the knowledge graph or browse `CHANGELOG.md` / `release
 
 ---
 
-## Lifecycle Hooks (v6.9.0 → v6.15.6)
+## Lifecycle Hooks (v6.9.0 → v6.15.7)
 
 Navigator ships eight Claude Code hooks via the plugin manifest (`.claude-plugin/plugin.json`). They make Navigator state survive every session boundary and replace fragile "model, remember to…" prose with deterministic enforcement.
+
+Hook commands resolve via `${CLAUDE_PLUGIN_ROOT}` (the installed plugin directory) with a marketplace-path fallback. **v6.15.7** corrected a long-standing typo where the manifest referenced the non-existent `${CLAUDE_PLUGIN_DIR}` — it always expanded empty, forcing every install onto the fallback (the `main`-tracking marketplace checkout) since hooks moved into the manifest in v6.13.0.
 
 ### What ships
 
@@ -284,5 +286,5 @@ cd ~/Projects/tmp/nav-test
 
 ---
 
-**Last Updated**: 2026-06-02 (v6.15.6 — removed deleted nav_commit_reminder.py from public manifest; hook count corrected to nine)
+**Last Updated**: 2026-06-08 (v6.15.7 — corrected plugin hook env var `CLAUDE_PLUGIN_DIR` → `CLAUDE_PLUGIN_ROOT`; published audit-remediation wp1–wp11)
 **Powered By**: Navigator (Complete Framework)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -920,7 +920,7 @@ Navigator config in `.agent/.nav-config.json` (minimal subset shown; the live fi
 
 ```json
 {
-  "version": "6.15.6",
+  "version": "6.15.7",
   "project_management": "none",
   "task_prefix": "TASK",
   "team_chat": "none",


### PR DESCRIPTION
Post-release doc drift cleanup. `bump-version.sh` updates the 5 canonical version files but not (a) the Nav index (`.agent/DEVELOPMENT-README.md`, not a gated bump location) or (b) the embedded `.nav-config.json` sample inside CLAUDE.md (only its footer is gated).

- **DEVELOPMENT-README.md**: plugin-version ref, `Lifecycle Hooks` heading, and footer → v6.15.7; added a note documenting `${CLAUDE_PLUGIN_ROOT}` hook resolution + the v6.15.7 typo fix so it can't silently regress.
- **CLAUDE.md**: config-sample `version` 6.15.6 → 6.15.7.

README badge already at 6.15.7. `version-management.md` SOP left as-is (audit script is SSOT-derived; its 6.15.6 references are teaching examples). Docs-only, no version bump.