### PR TITLE
GH-25: fix(updater): validate plugin.json ↔ release tag consistency before offering or applying updates

### DIFF
--- a/skills/nav-start/functions/auto_updater.py
+++ b/skills/nav-start/functions/auto_updater.py
@@ -23,8 +23,10 @@ import sys
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 from urllib import request
+
+REPO = 'alekspetrov/navigator'
 
 
 # --- Version Detection (from nav-upgrade/version_detector.py) ---
@@ -66,24 +68,112 @@ def get_current_version() -> Optional[str]:
         return None
 
 
-def get_latest_version_from_github() -> Dict:
-    """Get latest Navigator version from GitHub releases API."""
+def fetch_candidate_releases() -> List[Dict]:
+    """Fetch recent releases from GitHub, newest first, excluding drafts/prereleases.
+
+    Raises on network/API failure - caller decides how to handle it.
+    """
+    url = f'https://api.github.com/repos/{REPO}/releases?per_page=10'
+    req = request.Request(url)
+    req.add_header('User-Agent', 'Navigator-Auto-Updater')
+
+    with request.urlopen(req, timeout=10) as response:
+        data = json.load(response)
+
+    return [r for r in data if not r.get('draft') and not r.get('prerelease')]
+
+
+def validate_release_tag(tag_name: str) -> Dict:
+    """Validate that a release tag's plugin.json version matches the tag itself.
+
+    Mirrors nav-upgrade/version_detector.validate_release_tag: a release
+    published without a matching plugin.json bump would otherwise be offered
+    as an update that never actually changes the installed version, causing
+    a phantom-update loop every session. A validation fetch failure fails
+    open (offer the update) so offline/flaky networks don't block updates.
+    """
+    expected_version = tag_name.lstrip('v')
+    url = f'https://raw.githubusercontent.com/{REPO}/{tag_name}/.claude-plugin/plugin.json'
+
     try:
-        url = 'https://api.github.com/repos/alekspetrov/navigator/releases/latest'
         req = request.Request(url)
         req.add_header('User-Agent', 'Navigator-Auto-Updater')
 
         with request.urlopen(req, timeout=10) as response:
             data = json.load(response)
-            tag_name = data.get('tag_name', '')
-            version = tag_name.lstrip('v')
-            return {
-                'version': version,
-                'release_url': data.get('html_url', ''),
-                'release_date': data.get('published_at', '').split('T')[0]
-            }
+            plugin_version = data.get('version')
+    except Exception:
+        return {'valid': True, 'plugin_version': None, 'network_error': True}
+
+    return {
+        'valid': plugin_version == expected_version,
+        'plugin_version': plugin_version,
+        'network_error': False,
+    }
+
+
+def get_latest_version_from_github() -> Dict:
+    """Get latest valid Navigator version from GitHub releases API.
+
+    Walks releases newest-first and skips any whose plugin.json version
+    doesn't match its tag (malformed release).
+    """
+    try:
+        candidates = fetch_candidate_releases()
     except Exception as e:
         return {'version': None, 'error': str(e)}
+
+    for release in candidates:
+        tag_name = release.get('tag_name', '')
+        if not tag_name:
+            continue
+
+        validation = validate_release_tag(tag_name)
+        if not validation['valid']:
+            print(
+                f"release {tag_name} has plugin.json {validation['plugin_version']} "
+                "— malformed release, ignoring",
+                file=sys.stderr
+            )
+            continue
+
+        return {
+            'version': tag_name.lstrip('v'),
+            'release_url': release.get('html_url', ''),
+            'release_date': release.get('published_at', '').split('T')[0]
+        }
+
+    return {
+        'version': None,
+        'error': 'No valid release found (all candidates failed plugin.json validation)'
+    }
+
+
+def get_installed_plugin_version() -> Optional[str]:
+    """Read the version from the highest-versioned cached plugin install.
+
+    Used post-update to verify `claude plugin update` actually landed the
+    target version, not just that the command exited 0 - a malformed
+    release can report success while the cache still holds the old version.
+    """
+    cache_root = Path.home() / '.claude' / 'plugins' / 'cache'
+    candidates = list(cache_root.glob('*/navigator/*/.claude-plugin/plugin.json'))
+
+    def _version_key(plugin_json: Path):
+        version_dir = plugin_json.parent.parent.name
+        return [int(x) for x in re.findall(r'\d+', version_dir)]
+
+    for plugin_json in sorted(candidates, key=_version_key, reverse=True):
+        try:
+            with open(plugin_json, 'r') as f:
+                data = json.load(f)
+                version = data.get('version')
+                if version:
+                    return version
+        except (json.JSONDecodeError, OSError):
+            continue
+
+    return None
 
 
 def compare_versions(current: str, latest: str) -> int:
@@ -475,6 +565,21 @@ def auto_update(config_path: str = '.agent/.nav-config.json') -> Dict:
             'latest_version': latest_version
         }
 
+    # Skip releases already flagged as malformed this project - avoids a
+    # per-session phantom-update prompt for the same bad tag.
+    ignored_releases = auto_update_config.get('ignored_releases', [])
+    if latest_version in ignored_releases:
+        auto_update_config['last_check'] = datetime.now().isoformat()
+        config['auto_update'] = auto_update_config
+        save_config(config, config_path)
+
+        return {
+            'status': 'skipped',
+            'message': f'Release v{latest_version} previously failed verification - ignoring until a newer release appears',
+            'current_version': current_version,
+            'latest_version': latest_version
+        }
+
     # Update available - attempt update
     update_result = update_plugin_via_claude()
 
@@ -488,6 +593,27 @@ def auto_update(config_path: str = '.agent/.nav-config.json') -> Dict:
     save_config(config, config_path)
 
     if update_result['success']:
+        # Verify the installed version actually matches what we targeted -
+        # `claude plugin update` can report success on a malformed release
+        # that never lands the expected version.
+        installed_version = get_installed_plugin_version()
+        if installed_version != latest_version:
+            ignored_releases.append(latest_version)
+            auto_update_config['ignored_releases'] = ignored_releases
+            config['auto_update'] = auto_update_config
+            save_config(config, config_path)
+
+            return {
+                'status': 'failed',
+                'message': (
+                    f'updated marketplace but installed version is {installed_version}, '
+                    f'expected {latest_version} — malformed release?'
+                ),
+                'current_version': current_version,
+                'latest_version': latest_version,
+                'installed_version': installed_version
+            }
+
         # Sync project config with new version
         sync_result = sync_project_config(config_path, latest_version)
 

--- a/skills/nav-start/functions/test_auto_updater.py
+++ b/skills/nav-start/functions/test_auto_updater.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 """Tests for auto_updater.py"""
 
+import json
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -11,8 +13,11 @@ from unittest.mock import patch
 sys.path.insert(0, str(Path(__file__).parent))
 import auto_updater
 from auto_updater import (
+    auto_update,
     compare_versions,
     get_current_version,
+    get_installed_plugin_version,
+    get_latest_version_from_github,
     reinstall_plugin,
 )
 
@@ -162,6 +167,161 @@ class TestReinstallPlugin(unittest.TestCase):
         self.assertTrue(result["success"])
         self.assertEqual(result["method"], "reinstall")
         self.assertEqual(mock_run.call_count, 3)
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self):
+        return json.dumps(self._payload).encode()
+
+
+def _release(tag, prerelease=False, draft=False):
+    return {
+        "tag_name": tag,
+        "prerelease": prerelease,
+        "draft": draft,
+        "html_url": f"https://github.com/alekspetrov/navigator/releases/{tag}",
+        "published_at": "2026-07-01T00:00:00Z",
+    }
+
+
+class GetLatestVersionFromGithubTest(unittest.TestCase):
+    """Guards GH-25: same malformed-release validation as version_detector.py."""
+
+    def _mock_urlopen(self, releases, plugin_versions):
+        def fake_urlopen(req, timeout=10):
+            url = req.full_url if hasattr(req, "full_url") else req
+            if "api.github.com" in url:
+                return _FakeResponse(releases)
+            tag = url.split("/")[-3]
+            if tag not in plugin_versions:
+                raise OSError("network unreachable")
+            return _FakeResponse({"version": plugin_versions[tag]})
+
+        return patch.object(auto_updater.request, "urlopen", side_effect=fake_urlopen)
+
+    def test_matching_release_offered(self):
+        with self._mock_urlopen([_release("v6.16.0")], {"v6.16.0": "6.16.0"}):
+            result = get_latest_version_from_github()
+        self.assertEqual(result["version"], "6.16.0")
+
+    def test_mismatched_release_skipped(self):
+        releases = [_release("v6.17.0"), _release("v6.16.0")]
+        with self._mock_urlopen(
+            releases, {"v6.17.0": "6.16.9", "v6.16.0": "6.16.0"}
+        ):
+            result = get_latest_version_from_github()
+        self.assertEqual(result["version"], "6.16.0")
+
+    def test_validation_failure_fails_open(self):
+        with self._mock_urlopen([_release("v6.16.0")], {}):
+            result = get_latest_version_from_github()
+        self.assertEqual(result["version"], "6.16.0")
+
+
+class GetInstalledPluginVersionTest(unittest.TestCase):
+    def test_resolves_highest_version_from_cache(self):
+        with tempfile.TemporaryDirectory() as d:
+            home = Path(d)
+            base = home / ".claude" / "plugins" / "cache" / "navigator-marketplace" / "navigator"
+            for v in ["6.9.0", "6.16.0"]:
+                plugin_dir = base / v / ".claude-plugin"
+                plugin_dir.mkdir(parents=True)
+                (plugin_dir / "plugin.json").write_text(json.dumps({"version": v}))
+            with patch.object(auto_updater.Path, "home", lambda: home):
+                self.assertEqual(get_installed_plugin_version(), "6.16.0")
+
+
+class AutoUpdatePostUpdateVerificationTest(unittest.TestCase):
+    """Guards GH-25: `claude plugin update` reporting success is not enough -
+    the installed version must actually match the target, or this is a
+    phantom update from a malformed release."""
+
+    def _write_config(self, extra_auto_update=None):
+        config = {
+            "auto_update": {"enabled": True, **(extra_auto_update or {})}
+        }
+        f = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        )
+        json.dump(config, f)
+        f.close()
+        return f.name
+
+    def test_version_mismatch_after_update_reports_failed(self):
+        config_path = self._write_config()
+        try:
+            with patch.object(auto_updater, "get_current_version", return_value="6.15.0"), \
+                 patch.object(
+                     auto_updater, "get_latest_version_from_github",
+                     return_value={"version": "6.16.0"}
+                 ), \
+                 patch.object(
+                     auto_updater, "update_plugin_via_claude",
+                     return_value={"success": True, "method": "update"}
+                 ), \
+                 patch.object(
+                     auto_updater, "get_installed_plugin_version", return_value="6.15.0"
+                 ):
+                result = auto_update(config_path)
+
+            self.assertEqual(result["status"], "failed")
+            self.assertIn("malformed release", result["message"])
+
+            with open(config_path) as f:
+                saved = json.load(f)
+            self.assertIn("6.16.0", saved["auto_update"]["ignored_releases"])
+        finally:
+            Path(config_path).unlink()
+
+    def test_version_match_after_update_reports_updated(self):
+        config_path = self._write_config()
+        try:
+            with patch.object(auto_updater, "get_current_version", return_value="6.15.0"), \
+                 patch.object(
+                     auto_updater, "get_latest_version_from_github",
+                     return_value={"version": "6.16.0"}
+                 ), \
+                 patch.object(
+                     auto_updater, "update_plugin_via_claude",
+                     return_value={"success": True, "method": "update"}
+                 ), \
+                 patch.object(
+                     auto_updater, "get_installed_plugin_version", return_value="6.16.0"
+                 ), \
+                 patch.object(
+                     auto_updater, "sync_project_config",
+                     return_value={"success": True, "changes": []}
+                 ):
+                result = auto_update(config_path)
+
+            self.assertEqual(result["status"], "updated")
+        finally:
+            Path(config_path).unlink()
+
+    def test_ignored_release_is_skipped_without_reattempting_update(self):
+        config_path = self._write_config({"ignored_releases": ["6.16.0"]})
+        try:
+            with patch.object(auto_updater, "get_current_version", return_value="6.15.0"), \
+                 patch.object(
+                     auto_updater, "get_latest_version_from_github",
+                     return_value={"version": "6.16.0"}
+                 ), \
+                 patch.object(auto_updater, "update_plugin_via_claude") as mock_update:
+                result = auto_update(config_path)
+
+            self.assertEqual(result["status"], "skipped")
+            mock_update.assert_not_called()
+        finally:
+            Path(config_path).unlink()
 
 
 if __name__ == "__main__":

--- a/skills/nav-upgrade/functions/test_version_detector.py
+++ b/skills/nav-upgrade/functions/test_version_detector.py
@@ -81,5 +81,127 @@ class GetPluginJsonVersionTest(unittest.TestCase):
                 self.assertIsNone(vd.get_plugin_json_version())
 
 
+def _release(tag, prerelease=False, draft=False, body=""):
+    return {
+        "tag_name": tag,
+        "prerelease": prerelease,
+        "draft": draft,
+        "html_url": f"https://github.com/alekspetrov/navigator/releases/{tag}",
+        "published_at": "2026-07-01T00:00:00Z",
+        "body": body,
+    }
+
+
+class _FakeResponse:
+    """Minimal context-manager stand-in for urlopen()'s response object."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self):
+        return json.dumps(self._payload).encode()
+
+
+class GetLatestVersionFromGithubTest(unittest.TestCase):
+    """Guards GH-25: a release tag whose plugin.json disagrees with the tag
+    must never be offered as an update (phantom-update loop otherwise)."""
+
+    def _mock_urlopen(self, releases, plugin_versions):
+        """releases: list of release dicts from the /releases endpoint.
+        plugin_versions: dict tag -> version string returned by the raw
+        plugin.json fetch for that tag (missing tag -> raises, simulating a
+        network failure on the validation fetch only).
+        """
+
+        def fake_urlopen(req, timeout=10):
+            url = req.full_url if hasattr(req, "full_url") else req
+            if "api.github.com" in url:
+                return _FakeResponse(releases)
+            # raw.githubusercontent.com/<repo>/<tag>/.claude-plugin/plugin.json
+            tag = url.split("/")[-3]
+            if tag not in plugin_versions:
+                raise OSError("network unreachable")
+            return _FakeResponse({"version": plugin_versions[tag]})
+
+        return mock.patch.object(vd.request, "urlopen", side_effect=fake_urlopen)
+
+    def test_matching_release_is_offered(self):
+        releases = [_release("v6.16.0")]
+        with self._mock_urlopen(releases, {"v6.16.0": "6.16.0"}):
+            result = vd.get_latest_version_from_github()
+        self.assertEqual(result["version"], "6.16.0")
+        self.assertIsNone(result.get("error"))
+
+    def test_mismatched_release_skipped_next_considered(self):
+        releases = [_release("v6.17.0"), _release("v6.16.0")]
+        with self._mock_urlopen(
+            releases, {"v6.17.0": "6.16.9", "v6.16.0": "6.16.0"}
+        ):
+            result = vd.get_latest_version_from_github()
+        self.assertEqual(result["version"], "6.16.0")
+
+    def test_validation_fetch_error_fails_open(self):
+        """No plugin_versions entry for the tag -> validation fetch raises,
+        but the release must still be offered (fail-open)."""
+        releases = [_release("v6.16.0")]
+        with self._mock_urlopen(releases, {}):
+            result = vd.get_latest_version_from_github()
+        self.assertEqual(result["version"], "6.16.0")
+
+    def test_prerelease_excluded(self):
+        releases = [_release("v6.17.0-beta.1", prerelease=True), _release("v6.16.0")]
+        with self._mock_urlopen(
+            releases, {"v6.17.0-beta.1": "6.17.0-beta.1", "v6.16.0": "6.16.0"}
+        ):
+            result = vd.get_latest_version_from_github()
+        self.assertEqual(result["version"], "6.16.0")
+
+    def test_releases_endpoint_failure_returns_error(self):
+        with mock.patch.object(
+            vd.request, "urlopen", side_effect=OSError("network down")
+        ):
+            result = vd.get_latest_version_from_github()
+        self.assertIsNone(result["version"])
+        self.assertIn("network down", result["error"])
+
+    def test_all_candidates_malformed_returns_error(self):
+        releases = [_release("v6.16.0")]
+        with self._mock_urlopen(releases, {"v6.16.0": "6.15.9"}):
+            result = vd.get_latest_version_from_github()
+        self.assertIsNone(result["version"])
+
+
+class ValidateReleaseTagTest(unittest.TestCase):
+    def test_matching_version_is_valid(self):
+        def fake_urlopen(req, timeout=10):
+            return _FakeResponse({"version": "6.16.0"})
+
+        with mock.patch.object(vd.request, "urlopen", side_effect=fake_urlopen):
+            result = vd.validate_release_tag("v6.16.0")
+        self.assertTrue(result["valid"])
+        self.assertFalse(result["network_error"])
+
+    def test_mismatched_version_is_invalid(self):
+        def fake_urlopen(req, timeout=10):
+            return _FakeResponse({"version": "6.15.9"})
+
+        with mock.patch.object(vd.request, "urlopen", side_effect=fake_urlopen):
+            result = vd.validate_release_tag("v6.16.0")
+        self.assertFalse(result["valid"])
+        self.assertEqual(result["plugin_version"], "6.15.9")
+
+    def test_network_failure_fails_open(self):
+        with mock.patch.object(vd.request, "urlopen", side_effect=OSError("boom")):
+            result = vd.validate_release_tag("v6.16.0")
+        self.assertTrue(result["valid"])
+        self.assertTrue(result["network_error"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/skills/nav-upgrade/functions/version_detector.py
+++ b/skills/nav-upgrade/functions/version_detector.py
@@ -14,8 +14,10 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 from urllib import request
+
+REPO = 'alekspetrov/navigator'
 
 
 def get_current_version() -> Optional[str]:
@@ -96,41 +98,111 @@ def get_plugin_json_version() -> Optional[str]:
     return None
 
 
-def get_latest_version_from_github() -> Dict:
+def fetch_candidate_releases() -> List[Dict]:
     """
-    Get latest Navigator version from GitHub releases API.
+    Fetch recent releases from GitHub, newest first, excluding drafts/prereleases.
+
+    Raises on network/API failure - caller decides how to handle it.
+    """
+    url = f'https://api.github.com/repos/{REPO}/releases?per_page=10'
+    req = request.Request(url)
+    req.add_header('User-Agent', 'Navigator-Version-Detector')
+
+    with request.urlopen(req, timeout=10) as response:
+        data = json.load(response)
+
+    return [r for r in data if not r.get('draft') and not r.get('prerelease')]
+
+
+def validate_release_tag(tag_name: str) -> Dict:
+    """
+    Validate that a release tag's plugin.json version matches the tag itself.
+
+    A release published without a matching plugin.json version bump (bad
+    automation, or a human tagging before the version sync) would otherwise
+    be offered as an update that never actually changes the installed
+    version, causing a phantom-update loop every session.
 
     Returns:
-        Dict with version, release_url, and changes
+        Dict with:
+        - valid: True if plugin.json version matches the tag, or if the
+          validation fetch itself failed (fail-open - don't block updates
+          on a flaky/offline network)
+        - plugin_version: the version found in plugin.json, or None
+        - network_error: True if the validation fetch failed
     """
-    try:
-        url = 'https://api.github.com/repos/alekspetrov/navigator/releases/latest'
+    expected_version = tag_name.lstrip('v')
+    url = f'https://raw.githubusercontent.com/{REPO}/{tag_name}/.claude-plugin/plugin.json'
 
+    try:
         req = request.Request(url)
         req.add_header('User-Agent', 'Navigator-Version-Detector')
 
         with request.urlopen(req, timeout=10) as response:
             data = json.load(response)
+            plugin_version = data.get('version')
+    except Exception:
+        return {'valid': True, 'plugin_version': None, 'network_error': True}
 
-            # Extract version from tag_name (e.g., "v3.3.0" → "3.3.0")
-            tag_name = data.get('tag_name', '')
-            version = tag_name.lstrip('v')
+    return {
+        'valid': plugin_version == expected_version,
+        'plugin_version': plugin_version,
+        'network_error': False,
+    }
 
-            # Parse release notes for key changes
-            body = data.get('body', '')
-            changes = parse_release_notes(body)
 
-            return {
-                'version': version,
-                'release_url': data.get('html_url', ''),
-                'release_date': data.get('published_at', '').split('T')[0],
-                'changes': changes
-            }
+def get_latest_version_from_github() -> Dict:
+    """
+    Get latest valid Navigator version from GitHub releases API.
+
+    Walks releases newest-first and skips any whose plugin.json version
+    doesn't match its tag (malformed release) so it's never offered as an
+    update. A validation fetch failure fails open - that candidate is
+    offered as-is rather than blocking on network flakiness.
+
+    Returns:
+        Dict with version, release_url, and changes
+    """
+    try:
+        candidates = fetch_candidate_releases()
     except Exception as e:
         return {
             'version': None,
             'error': str(e)
         }
+
+    for release in candidates:
+        tag_name = release.get('tag_name', '')
+        if not tag_name:
+            continue
+
+        validation = validate_release_tag(tag_name)
+        if not validation['valid']:
+            print(
+                f"release {tag_name} has plugin.json {validation['plugin_version']} "
+                "— malformed release, ignoring",
+                file=sys.stderr
+            )
+            continue
+
+        # Extract version from tag_name (e.g., "v3.3.0" → "3.3.0")
+        version = tag_name.lstrip('v')
+
+        # Parse release notes for key changes
+        body = release.get('body', '')
+        changes = parse_release_notes(body)
+
+        return {
+            'version': version,
+            'release_url': release.get('html_url', ''),
+            'release_date': release.get('published_at', '').split('T')[0],
+            'changes': changes
+        }
+
+    return {
+        'version': None,
+        'error': 'No valid release found (all candidates failed plugin.json validation)'
+    }
 
 
 def parse_release_notes(body: str) -> Dict:


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-25.

Closes #25

## Changes

GitHub Issue #25: fix(updater): validate plugin.json ↔ release tag consistency before offering or applying updates

## Context

The updater trusts GitHub releases blindly. `version_detector.py` (skills/nav-upgrade/functions/) compares the installed version against the latest GitHub release tag, and `auto_updater.py` (skills/nav-start/functions/) then runs `claude plugin update`. If a release tag ever exists WITHOUT a matching `.claude-plugin/plugin.json` bump at that tag — automation publishing a release (near-miss 2026-07-07: the Pilot autopilot hub had release automation default-on for this repo), or a human tagging before the version sync — every user enters a **phantom-update loop**: "update available" → update runs → installed version unchanged → repeat next session. With `auto_update.enabled: true` this fires on every session start.

Harden the CONSUMER so no malformed release can harm users, regardless of source.

## Task

1. **`version_detector.py` — validate before offering.** For the candidate release tag, fetch `https://raw.githubusercontent.com/alekspetrov/navigator/<tag>/.claude-plugin/plugin.json` and compare its `version` to the tag (strip `v` prefix). Mismatch → skip that release with a stderr warning (`release <tag> has plugin.json <ver> — malformed release, ignoring`) and consider the next-newest release. Network failure on the validation fetch → fail-open to current behavior (offer the update) so offline/flaky networks don't block updates.
2. **`auto_updater.py` — verify after applying.** After `claude plugin update` reports success, read the installed plugin.json version (the plugin cache dir the updater already knows). Installed != target → return `status: "failed"` with a clear message (`updated marketplace but installed version is <x>, expected <y> — malformed release?`) instead of `"updated"`. Never retry-loop the same target within a session (mark the tag as bad in the JSON result so nav-start shows the warning once, not every session — persisting a skip-list in `.nav-config.json` under `auto_update.ignored_releases` is acceptable).
3. Same validation in the nav-upgrade skill flow (it shares these functions — verify no divergent copies).

## Tests

Project test conventions apply (Python, function-level tests near the skill functions):
- version_detector: matching release → offered; mismatched plugin.json → skipped with warning, next release considered; fetch error → fail-open; prerelease handling unchanged.
- auto_updater: post-update version match → updated; mismatch → failed status + message; ignored-release skip honored.

## Acceptance criteria

- [ ] A GitHub release whose tag ≠ plugin.json version at that tag is never offered and never reported as a successful update
- [ ] No phantom-update loop: a malformed latest release surfaces one warning, not a per-session update prompt
- [ ] Offline validation failure does not block legitimate updates
- [ ] Existing updater behavior for well-formed releases unchanged

## Out of scope

- Release-creation tooling (nav-release) changes
- Marketplace.json validation (separate concern)
- Do NOT decompose this issue

Origin: Pilot hub design session 2026-07-07 (release-automation rollout; defense-in-depth layer 3). Companion fix on the Pilot side: qf-studio/pilot — per-project release opt-in.
